### PR TITLE
feat: Adds trustbloc-did-method support (wasm)

### DIFF
--- a/cmd/agent-js-worker/go.mod
+++ b/cmd/agent-js-worker/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/trustbloc/agent-sdk v0.0.0
 	github.com/trustbloc/edge-core v0.1.5-0.20200916124536-c32454a16108
+	github.com/trustbloc/trustbloc-did-method v0.1.5-0.20201020134433-7a5917ab71d7
 )
 
 replace github.com/trustbloc/agent-sdk => ../../

--- a/cmd/agent-js-worker/go.sum
+++ b/cmd/agent-js-worker/go.sum
@@ -21,6 +21,7 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/aws/aws-sdk-go v1.25.39/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833 h1:yCfXxYaelOyqnia8F/Yng47qhmfC9nKTRIbYRrRueq4=
 github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833/go.mod h1:8c4/i2VlovMO2gBnHGQPN5EJw+H0lx1u/5p+cgsXtCk=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
@@ -148,6 +149,7 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hyperledger/aries-framework-go v0.1.4 h1:Ng7NGgo2VWnQHVxyiMwbD2EtFuoKtShU3/8cZb+vuD8=
 github.com/hyperledger/aries-framework-go v0.1.4/go.mod h1:mzdpIGEYiXCkicIrDmrMDuLx3AJPSlvIaJMrzJNFNdI=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201017112511-5734c20820a9/go.mod h1:cLWhBbjgrA04Di9ufGqAuTCdoM33Xq4Cuc3fL/VLAgI=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201019182031-a751c3ac7ed8/go.mod h1:Ti+du/ZwtBYjV8TkuohDGLJHxQnJa8x4iGqG2xdJCTc=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201020160650-4535370d64e4 h1:JtH4WXkXkeITuF68vXdSAkS1qtphih324GLfpAuoYtI=
 github.com/hyperledger/aries-framework-go v0.1.5-0.20201020160650-4535370d64e4/go.mod h1:SBdYSdfDb3qNfg6XAHNoSOLV0NGmEmIFWdr7JFZ6rYo=
 github.com/hyperledger/aries-framework-go/component/storage/jsindexeddb v0.0.0-20201020181044-b37cbb80b085 h1:PgW9gkGzDoMjZozAMV8YNYOgBaIYTwKSdEYnxduR7Nw=
@@ -294,6 +296,8 @@ github.com/trustbloc/sidetree-core-go v0.1.5-0.20201006193409-11b061380f5b h1:2i
 github.com/trustbloc/sidetree-core-go v0.1.5-0.20201006193409-11b061380f5b/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/trustbloc-did-method v0.1.5-0.20201013133524-7c8154bccbd3 h1:zIy52EPmJRJuT/NsjXRR0TK1U1fcjLPdDgbi/D56X7M=
 github.com/trustbloc/trustbloc-did-method v0.1.5-0.20201013133524-7c8154bccbd3/go.mod h1:TU3hVf/QgRtD6Zww65Vk8NuhF+ohpErKrRTBiNOVcKY=
+github.com/trustbloc/trustbloc-did-method v0.1.5-0.20201020134433-7a5917ab71d7 h1:p0+YneQi/gwegShOKkTi6np+k781PwCM8lnGhCqAd0M=
+github.com/trustbloc/trustbloc-did-method v0.1.5-0.20201020134433-7a5917ab71d7/go.mod h1:k4GzBoDrftehgE8lssSVYTHF+jnG9ENr1nLFC2tlhOk=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/cmd/agent-js-worker/src/agent.js
+++ b/cmd/agent-js-worker/src/agent.js
@@ -84,6 +84,8 @@ function newMsg(pkg, fn, payload) {
  *      "outbound-transport": ["ws", "http"],
  *      "transport-return-route": "all",
  *      "log-level": "debug",
+ *      "blocDomain": "http://trustbloc.domain.com",
+ *      "trustbloc-resolver": "http://trustbloc.resolver.com",
  *      "agent-rest-url": "http://controller.api.example.com",
  *      "agent-rest-wshook": "ws://controller.api.example.com"
  * }


### PR DESCRIPTION
This PR adds trustbloc-did-method support. did-method can be configured with the following options:
* blocDomain
* trustbloc-resolver

NOTE: `trustbloc` method can be overwritten by using `"http-resolver-url": ["trustbloc@https://uniresolver.io/1.0/identifiers"]`

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>