### PR TITLE
ci: Fixes docker publish job

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
           echo '@hyperledger:registry=https://npm.pkg.github.com' >> ~/.npmrc
           echo '@trustbloc-cicd:registry=https://npm.pkg.github.com' >> ~/.npmrc
           make agent-rest-docker
-          docker tag ${AGENT_SDK_PKG}:latest ${AGENT_SDK_PKG}:${AGENT_SDK_TAG}
+          docker tag docker.pkg.github.com/trustbloc/agent-sdk/agent-sdk-rest:latest ${AGENT_SDK_PKG}:${AGENT_SDK_TAG}
           docker push ${AGENT_SDK_PKG}:${AGENT_SDK_TAG}
           cd ./cmd/agent-js-worker
           sed -i 's/"version": "0.1.0"/"version": "'$NPM_PKG_TAG'"/g' package.json


### PR DESCRIPTION
Docker publish job doesn’t work due to `Error response from daemon: No such image: docker.pkg.github.com/trustbloc-cicd/snapshot/agent-sdk-rest:latest`.  This PR fixes it.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>