### PR TITLE
chore: rename 'purpose' to 'purposes'

### DIFF
--- a/pkg/controller/command/didclient/models.go
+++ b/pkg/controller/command/didclient/models.go
@@ -29,7 +29,7 @@ type PublicKey struct {
 	Type     string   `json:"type,omitempty"`
 	Encoding string   `json:"encoding,omitempty"`
 	KeyType  string   `json:"keyType,omitempty"`
-	Purposes []string `json:"purpose,omitempty"`
+	Purposes []string `json:"purposes,omitempty"`
 	Recovery bool     `json:"recovery,omitempty"`
 	Update   bool     `json:"update,omitempty"`
 	Value    string   `json:"value,omitempty"`


### PR DESCRIPTION
Rename 'purpose' to 'purposes'

Closes #32

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>