### PR TITLE
feat: Adds the possibility to inject storage (mobile)

### DIFF
--- a/cmd/agent-mobile/pkg/api/storage.go
+++ b/cmd/agent-mobile/pkg/api/storage.go
@@ -1,0 +1,69 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+// StoreIterator is the iterator for the latest snapshot of the underlying store.
+type StoreIterator interface {
+	// Next moves the iterator to the next key/value pair.
+	// It returns false if the iterator is exhausted.
+	Next() bool
+
+	// Free releases associated resources. Release should always success
+	// and can be called multiple times without causing error.
+	Free()
+
+	// Error returns any accumulated error. Exhausting all the key/value pairs
+	// is not considered to be an error.
+	Error() error
+
+	// Key returns the key of the current key/value pair, or nil if done.
+	// The caller should not modify the contents of the returned slice, and
+	// its contents may change on the next call to any 'seeks method'.
+	Key() []byte
+
+	// Value returns the value of the current key/value pair, or nil if done.
+	// The caller should not modify the contents of the returned slice, and
+	// its contents may change on the next call to any 'seeks method'.
+	Value() []byte
+}
+
+// Store is the storage interface.
+type Store interface {
+	// Put stores the key and the record
+	Put(k string, v []byte) error
+
+	// Get fetches the record based on key
+	Get(k string) ([]byte, error)
+
+	// Iterator returns an iterator for the latest snapshot of the
+	// underlying store
+	//
+	// Args:
+	//
+	// startKey: Start of the key range, include in the range.
+	// endKey: End of the key range, not include in the range.
+	//
+	// Returns:
+	//
+	// StoreIterator: iterator for result range
+	Iterator(startKey, endKey string) StoreIterator
+
+	// Delete will delete a record with k key
+	Delete(k string) error
+}
+
+// StorageProvider defines storage interface.
+type StorageProvider interface {
+	// OpenStore opens a store with given name space and returns the handle
+	OpenStore(name string) (Store, error)
+
+	// CloseStore closes store of given name space
+	CloseStore(name string) error
+
+	// Close closes all stores created under this store provider
+	Close() error
+}

--- a/cmd/agent-mobile/pkg/wrappers/command/aries.go
+++ b/cmd/agent-mobile/pkg/wrappers/command/aries.go
@@ -39,6 +39,7 @@ import (
 	"github.com/trustbloc/agent-sdk/cmd/agent-mobile/pkg/api"
 	"github.com/trustbloc/agent-sdk/cmd/agent-mobile/pkg/wrappers/config"
 	"github.com/trustbloc/agent-sdk/cmd/agent-mobile/pkg/wrappers/notifier"
+	"github.com/trustbloc/agent-sdk/cmd/agent-mobile/pkg/wrappers/storage"
 	sdkcontroller "github.com/trustbloc/agent-sdk/pkg/controller"
 	sdkcommand "github.com/trustbloc/agent-sdk/pkg/controller/command"
 	"github.com/trustbloc/agent-sdk/pkg/controller/command/didclient"
@@ -118,7 +119,11 @@ func prepareFrameworkOptions(opts *config.Options) ([]aries.Option, error) { // 
 		options = append(options, aries.WithTransportReturnRoute(opts.TransportReturnRoute))
 	}
 
-	options = append(options, aries.WithStoreProvider(mem.NewProvider()))
+	if opts.Storage != nil {
+		options = append(options, aries.WithStoreProvider(storage.New(opts.Storage)))
+	} else {
+		options = append(options, aries.WithStoreProvider(mem.NewProvider()))
+	}
 
 	VDRs, err := createVDRs(opts.HTTPResolvers, opts.TrustblocDomain, opts.TrustblocResolver)
 	if err != nil {

--- a/cmd/agent-mobile/pkg/wrappers/config/options.go
+++ b/cmd/agent-mobile/pkg/wrappers/config/options.go
@@ -22,6 +22,7 @@ type Options struct {
 	TrustblocResolver    string
 	WebsocketURL         string
 	Logger               api.LoggerProvider
+	Storage              api.StorageProvider
 	// expected to be ignored by gomobile
 	// not intended to be used by golang code
 	HTTPResolvers     []string

--- a/cmd/agent-mobile/pkg/wrappers/storage/storage.go
+++ b/cmd/agent-mobile/pkg/wrappers/storage/storage.go
@@ -1,0 +1,44 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package storage is not expected to be used by the mobile app.
+package storage
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+
+	"github.com/trustbloc/agent-sdk/cmd/agent-mobile/pkg/api"
+)
+
+// Provider represents storage provider.
+type Provider struct{ api.StorageProvider }
+
+// New returns new storage provider.
+func New(p api.StorageProvider) *Provider {
+	return &Provider{StorageProvider: p}
+}
+
+// OpenStore overwrites original method to satisfy the interface.
+func (p *Provider) OpenStore(name string) (storage.Store, error) {
+	_store, err := p.StorageProvider.OpenStore(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &store{Store: _store}, nil
+}
+
+type store struct{ api.Store }
+
+// Iterator overwrites original method to satisfy the interface.
+func (s *store) Iterator(startKey, endKey string) storage.StoreIterator {
+	return &iterator{StoreIterator: s.Store.Iterator(startKey, endKey)}
+}
+
+type iterator struct{ api.StoreIterator }
+
+// Release implements method to satisfy the interface.
+func (s *iterator) Release() { s.StoreIterator.Free() }

--- a/cmd/agent-mobile/pkg/wrappers/storage/storage_test.go
+++ b/cmd/agent-mobile/pkg/wrappers/storage/storage_test.go
@@ -1,0 +1,286 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package storage_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/storage/mem"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/agent-sdk/cmd/agent-mobile/pkg/api"
+	. "github.com/trustbloc/agent-sdk/cmd/agent-mobile/pkg/wrappers/storage"
+)
+
+type mockProvider struct{ storage.Provider }
+
+func newMock(p storage.Provider) *mockProvider {
+	return &mockProvider{Provider: p}
+}
+
+func (p *mockProvider) OpenStore(name string) (api.Store, error) {
+	_store, err := p.Provider.OpenStore(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mockStore{Store: _store}, nil
+}
+
+type mockStore struct{ storage.Store }
+
+func (s *mockStore) Iterator(startKey, endKey string) api.StoreIterator {
+	return &mockIterator{StoreIterator: s.Store.Iterator(startKey, endKey)}
+}
+
+type mockIterator struct{ storage.StoreIterator }
+
+func (s *mockIterator) Free() { s.StoreIterator.Release() }
+
+func TestMemStore(t *testing.T) {
+	t.Run("Test mem store put and get", func(t *testing.T) {
+		prov := New(newMock(mem.NewProvider()))
+		store, err := prov.OpenStore("test")
+		require.NoError(t, err)
+
+		const key = "did:example:123"
+		data := []byte("value")
+
+		err = store.Put(key, data)
+		require.NoError(t, err)
+
+		doc, err := store.Get(key)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc)
+		require.Equal(t, data, doc)
+
+		// test update
+		data = []byte(`{"key1":"value1"}`)
+		err = store.Put(key, data)
+		require.NoError(t, err)
+
+		doc, err = store.Get(key)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc)
+		require.Equal(t, data, doc)
+
+		// test update
+		update := []byte(`{"_key1":"value1"}`)
+		err = store.Put(key, update)
+		require.NoError(t, err)
+
+		doc, err = store.Get(key)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc)
+		require.Equal(t, update, doc)
+
+		did2 := "did:example:789"
+		_, err = store.Get(did2)
+		require.True(t, errors.Is(err, storage.ErrDataNotFound))
+
+		// nil key
+		_, err = store.Get("")
+		require.Error(t, err)
+
+		// nil value
+		err = store.Put(key, nil)
+		require.Error(t, err)
+
+		// nil key
+		err = store.Put("", data)
+		require.Error(t, err)
+
+		err = prov.Close()
+		require.NoError(t, err)
+
+		// try to get after provider is closed
+		_, err = store.Get(key)
+		require.Error(t, err)
+	})
+
+	t.Run("Test mem multi store put and get", func(t *testing.T) {
+		prov := New(newMock(mem.NewProvider()))
+		const commonKey = "did:example:1"
+		data := []byte("value1")
+		// create store 1 & store 2
+		store1, err := prov.OpenStore("store1")
+		require.NoError(t, err)
+
+		store2, err := prov.OpenStore("store2")
+		require.NoError(t, err)
+
+		// put in store 1
+		err = store1.Put(commonKey, data)
+		require.NoError(t, err)
+
+		// get in store 1 - found
+		doc, err := store1.Get(commonKey)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc)
+		require.Equal(t, data, doc)
+
+		// get in store 2 - not found
+		doc, err = store2.Get(commonKey)
+		require.Error(t, err)
+		require.Equal(t, err, storage.ErrDataNotFound)
+		require.Empty(t, doc)
+
+		// put in store 2
+		err = store2.Put(commonKey, data)
+		require.NoError(t, err)
+
+		// get in store 2 - found
+		doc, err = store2.Get(commonKey)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc)
+		require.Equal(t, data, doc)
+
+		// create new store 3 with same name as store1
+		store3, err := prov.OpenStore("store1")
+		require.NoError(t, err)
+
+		// get in store 3 - found
+		doc, err = store3.Get(commonKey)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc)
+		require.Equal(t, data, doc)
+	})
+
+	t.Run("Test mem multi store close by name", func(t *testing.T) {
+		prov := New(newMock(mem.NewProvider()))
+
+		const commonKey = "did:example:1"
+		data := []byte("value1")
+
+		storeNames := []string{"store_1", "store_2", "store_3", "store_4", "store_5"}
+		storesToClose := []string{"store_1", "store_3", "store_5"}
+
+		for _, name := range storeNames {
+			store, e := prov.OpenStore(name)
+			require.NoError(t, e)
+
+			e = store.Put(commonKey, data)
+			require.NoError(t, e)
+		}
+
+		for _, name := range storeNames {
+			store, e := prov.OpenStore(name)
+			require.NoError(t, e)
+			require.NotNil(t, store)
+
+			dataRead, e := store.Get(commonKey)
+			require.NoError(t, e)
+			require.Equal(t, data, dataRead)
+		}
+
+		for _, name := range storesToClose {
+			store, e := prov.OpenStore(name)
+			require.NoError(t, e)
+			require.NotNil(t, store)
+
+			e = prov.CloseStore(name)
+			require.NoError(t, e)
+
+			dataRead, e := store.Get(commonKey)
+			require.Error(t, e)
+			require.Empty(t, dataRead)
+		}
+
+		// try close all again
+		require.NoError(t, prov.Close())
+	})
+
+	t.Run("Test mem store iterator", func(t *testing.T) {
+		prov := New(newMock(mem.NewProvider()))
+		store, err := prov.OpenStore("test-iterator")
+		require.NoError(t, err)
+
+		const valPrefix = "val-for-%s"
+		keys := []string{"abc_123", "abc_124", "abc_125", "abc_126", "jkl_123", "mno_123", "dab_123"}
+
+		for _, key := range keys {
+			err = store.Put(key, []byte(fmt.Sprintf(valPrefix, key)))
+			require.NoError(t, err)
+		}
+
+		itr := store.Iterator("abc_", "abc_"+storage.EndKeySuffix)
+		verifyItr(t, itr, 4, "abc_")
+
+		itr = store.Iterator("", "")
+		verifyItr(t, itr, 0, "")
+
+		itr = store.Iterator("abc_", "mno_"+storage.EndKeySuffix)
+		verifyItr(t, itr, 7, "")
+
+		itr = store.Iterator("abc_", "mno_123")
+		verifyItr(t, itr, 6, "")
+
+		itr = store.Iterator("t_", "t_"+storage.EndKeySuffix)
+		verifyItr(t, itr, 0, "")
+	})
+}
+
+func verifyItr(t *testing.T, itr storage.StoreIterator, count int, prefix string) {
+	t.Helper()
+
+	var vals []string
+
+	for itr.Next() {
+		if prefix != "" {
+			require.True(t, strings.HasPrefix(string(itr.Key()), prefix))
+		}
+
+		vals = append(vals, string(itr.Value()))
+	}
+	require.Len(t, vals, count)
+
+	itr.Release()
+	require.False(t, itr.Next())
+	require.Empty(t, itr.Key())
+	require.Empty(t, itr.Value())
+	require.Error(t, itr.Error())
+	require.Contains(t, itr.Error().Error(), "iterator released")
+}
+
+func TestMemStore_Delete(t *testing.T) {
+	const commonKey = "did:example:1234"
+
+	prov := New(newMock(mem.NewProvider()))
+	data := []byte("value1")
+	// create store 1 & store 2
+	store1, err := prov.OpenStore("store1")
+	require.NoError(t, err)
+
+	// put in store 1
+	err = store1.Put(commonKey, data)
+	require.NoError(t, err)
+
+	// get in store 1 - found
+	doc, err := store1.Get(commonKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, doc)
+	require.Equal(t, data, doc)
+
+	// now try Delete with an empty key - should fail
+	err = store1.Delete("")
+	require.EqualError(t, err, "key is mandatory")
+
+	err = store1.Delete("k1")
+	require.NoError(t, err)
+
+	// finally test Delete an existing key
+	err = store1.Delete(commonKey)
+	require.NoError(t, err)
+
+	doc, err = store1.Get(commonKey)
+	require.EqualError(t, err, storage.ErrDataNotFound.Error())
+	require.Empty(t, doc)
+}


### PR DESCRIPTION
Adds the possibility to inject storage.
Clients can implement and provide their own storage implementation.
To do that the `StorageProvider` interface must be implemented:

```
// StorageProvider defines storage interface.
type StorageProvider interface {
	// OpenStore opens a store with given name space and returns the handle
	OpenStore(name string) (Store, error)

	// CloseStore closes store of given name space
	CloseStore(name string) error

	// Close closes all stores created under this store provider
	Close() error
}

// Store is the storage interface.
type Store interface {
	// Put stores the key and the record
	Put(k string, v []byte) error

	// Get fetches the record based on key
	Get(k string) ([]byte, error)

	// Iterator returns an iterator for the latest snapshot of the
	// underlying store
	//
	// Args:
	//
	// startKey: Start of the key range, include in the range.
	// endKey: End of the key range, not include in the range.
	//
	// Returns:
	//
	// StoreIterator: iterator for result range
	Iterator(startKey, endKey string) StoreIterator

	// Delete will delete a record with k key
	Delete(k string) error
}

// StoreIterator is the iterator for the latest snapshot of the underlying store.
type StoreIterator interface {
	// Next moves the iterator to the next key/value pair.
	// It returns false if the iterator is exhausted.
	Next() bool

	// Free releases associated resources. Release should always success
	// and can be called multiple times without causing error.
	Free()

	// Error returns any accumulated error. Exhausting all the key/value pairs
	// is not considered to be an error.
	Error() error

	// Key returns the key of the current key/value pair, or nil if done.
	// The caller should not modify the contents of the returned slice, and
	// its contents may change on the next call to any 'seeks method'.
	Key() []byte

	// Value returns the value of the current key/value pair, or nil if done.
	// The caller should not modify the contents of the returned slice, and
	// its contents may change on the next call to any 'seeks method'.
	Value() []byte
}
```

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>