### PR TITLE
fix: Unit test coverage file doesn't include agent-sdk folder

### DIFF
--- a/scripts/check_unit.sh
+++ b/scripts/check_unit.sh
@@ -18,7 +18,7 @@ if [ -f profile.out ]; then
 fi
 }
 
-# Running edge-store unit tests
+# Running agent-sdk unit tests
 PKGS=`go list github.com/trustbloc/agent-sdk/... 2> /dev/null`
 go test $PKGS -count=1 -race -coverprofile=profile.out -covermode=atomic -timeout=10m
 amend_coverage_file
@@ -27,6 +27,7 @@ amend_coverage_file
 cd cmd/agent-mobile
 PKGS=`go list github.com/trustbloc/cmd/agent-mobile/... 2> /dev/null`
 go test $PKGS -count=1 -race -coverprofile=profile.out -covermode=atomic -timeout=10m
+amend_coverage_file
 cd "$pwd"
 
 # Running agent rest unit tests


### PR DESCRIPTION
Fixes an issue where the unit test coverage for the agent-sdk folder wasn't being included.

Also fixes an incorrect name in a comment in the check_unit.sh script.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>