### PR TITLE
feat: Adds REST API bdd tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 GOBIN_PATH             = $(abspath .)/build/bin
 ARIES_AGENT_REST_PATH=cmd/agent-rest
 ARIES_AGENT_MOBILE_PATH=cmd/agent-mobile
+ARIES_FRAMEWORK_COMMIT=1e234a0af6c6
 PROJECT_ROOT = github.com/trustbloc/agent-sdk
 OPENAPI_SPEC_PATH=build/rest/openapi/spec
 OPENAPI_DOCKER_IMG=quay.io/goswagger/swagger
@@ -56,6 +57,10 @@ agent-rest-docker:
 	--build-arg ALPINE_VER=$(ALPINE_VER) \
 	--build-arg GO_TAGS=$(GO_TAGS) \
 	--build-arg GOPROXY=$(GOPROXY) .
+
+.PHONY: rest-api-bdd
+rest-api-bdd: clean agent-rest-docker
+	@ARIES_FRAMEWORK_COMMIT=$(ARIES_FRAMEWORK_COMMIT) scripts/aries_bdd_tests.sh
 
 .PHONY: unit-test-mobile
 unit-test-mobile:

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -51,6 +51,27 @@ jobs:
       - checkout: self
       - script: make unit-test-wasm
         displayName: Run unit test wasm
+
+  - job: AgentRestAPTest
+    pool:
+      vmImage: ubuntu-18.04
+    timeoutInMinutes: 30
+    steps:
+      - template: azp-dependencies.yml
+      - checkout: self
+      - bash: |
+          function logout {
+            docker logout
+          }
+          trap logout EXIT
+          source ci/version_var.sh
+          echo $DOCKER_PASSWORD | docker login docker.pkg.github.com --username $DOCKER_USER --password-stdin
+          make rest-api-bdd
+        env:
+          DOCKER_PASSWORD: $(DOCKER_PASSWORD)
+          DOCKER_USER: $(DOCKER_USER)
+        displayName: Run agent REST API tests (docker)
+
   - job: Publish
     dependsOn:
       - Checks

--- a/deployments/agent-rest/docker-compose.yml
+++ b/deployments/agent-rest/docker-compose.yml
@@ -105,4 +105,4 @@ services:
 
 networks:
   agent_sdk_net:
-    driver: bridge
+    external: true

--- a/deployments/sidetree-mock/docker-compose.yml
+++ b/deployments/sidetree-mock/docker-compose.yml
@@ -19,8 +19,8 @@ services:
     volumes:
       - ../keys/tls:/etc/sidetree/tls
     networks:
-      - agent-sdk-rest-net
+      - agent_sdk_net
 
 networks:
-  agent-sdk-rest-net:
+  agent_sdk_net:
     external: true

--- a/scripts/aries_bdd_tests.sh
+++ b/scripts/aries_bdd_tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+echo "Copying aries feature file..."
+pwd=$(pwd)
+rm -rf ./build/aries-framework-go
+git clone -b master https://github.com/hyperledger/aries-framework-go ./build/aries-framework-go
+cd ./build/aries-framework-go || exit
+
+git checkout ${ARIES_FRAMEWORK_COMMIT}
+
+sed -i '' -e "1,/AGENT_REST_IMAGE.*/s/AGENT_REST_IMAGE.*/AGENT_REST_IMAGE=docker.pkg.github.com\/trustbloc\/agent-sdk\/agent-sdk-rest/" test/bdd/fixtures/agent-rest/.env
+sed -i '' -e "s/aries-agent-rest /agent-rest /" test/bdd/fixtures/agent-rest/docker-compose.yml
+
+make clean generate-test-keys sample-webhook-docker sidetree-cli bdd-test-go
+
+go test -count=1 -v -cover . -p 1 -timeout=20m -race
+
+rm -rf aries-framework-go
+cd $pwd || exit


### PR DESCRIPTION
This PR adds the possibility to run Aries BDD tests based on the agent-sdk docker image.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>