### PR TITLE
fix: Missing key ID

### DIFF
--- a/cmd/agent-js-worker/main.go
+++ b/cmd/agent-js-worker/main.go
@@ -220,7 +220,8 @@ func testHandlers() map[string]map[string]func(*command) *result {
 				return newErrResult(c.ID, "an error !!")
 			},
 			"timeout": func(c *command) *result {
-				const echoTimeout = 10 * time.Second
+				// TODO (#84) Reduce this timeout value back to something reasonable once EDV storage speed is improved.
+				const echoTimeout = 120 * time.Second
 
 				time.Sleep(echoTimeout)
 
@@ -848,7 +849,9 @@ func prepareKeyHandle(storeProvider storage.Provider, keyManager kms.KeyManager,
 
 	logger.Infof("Found existing key handle ID under store %s with store DB key ID %s.", keyIDStoreName, keyIDDBKeyName)
 
-	keyHandleUntyped, getErr := keyManager.Get(string(keyIDBytes))
+	keyID := string(keyIDBytes)
+
+	keyHandleUntyped, getErr := keyManager.Get(keyID)
 	if getErr != nil {
 		return "", nil, fmt.Errorf("failed to get key handle from key manager: %w", getErr)
 	}
@@ -858,7 +861,7 @@ func prepareKeyHandle(storeProvider storage.Provider, keyManager kms.KeyManager,
 		return "", nil, errors.New("unable to assert key handle as a key set handle pointer")
 	}
 
-	return "", kh, nil
+	return keyID, kh, nil
 }
 
 func setLogLevel(logLevel string) error {

--- a/cmd/agent-js-worker/src/agent.js
+++ b/cmd/agent-js-worker/src/agent.js
@@ -10,7 +10,8 @@ SPDX-License-Identifier: Apache-2.0
 const notifierWait = 10000
 
 // time out for command operations
-const commandTimeout = 20000
+// TODO (#84) Reduce this timeout value back to something reasonable once EDV storage speed is improved.
+const commandTimeout = 120000
 
 __webpack_public_path__ = "/agent-js-worker/"
 

--- a/pkg/controller/command/mediatorclient/command.go
+++ b/pkg/controller/command/mediatorclient/command.go
@@ -68,8 +68,8 @@ const (
 	stateCompleteTopic = "state-complete-topic"
 
 	// timeout constants.
-	didExchangeTimeOut = 20 * time.Second
-	sendMsgTimeOut     = 20 * time.Second
+	didExchangeTimeOut = 120 * time.Second
+	sendMsgTimeOut     = 120 * time.Second
 
 	// message types.
 	createConnRequestMsgType  = "https://trustbloc.dev/blinded-routing/1.0/create-conn-req"


### PR DESCRIPTION
- Fixes an issue where the EDV provider's JWE encrypter is missing the key ID when reusing the existing local key ID from IndexedDB storage.
- Increased command timeout. This is a temporary change and will be decreased back down to a more reasonable value in a future commit (see issue #84).

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>