### PR TITLE
refactor: remove https prefix

### DIFF
--- a/pkg/auth/zcapld/service.go
+++ b/pkg/auth/zcapld/service.go
@@ -155,7 +155,7 @@ func (a *didKeySignatureHashAlgorithm) sign(keyID string, data []byte) ([]byte, 
 	}
 
 	req, err := http.NewRequestWithContext(context.TODO(),
-		http.MethodPost, "https://"+a.s.authzKeyStoreURL+fmt.Sprintf(signEndpoint, keyID), bytes.NewBuffer(reqBytes))
+		http.MethodPost, a.s.authzKeyStoreURL+fmt.Sprintf(signEndpoint, keyID), bytes.NewBuffer(reqBytes))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
the prefix should be part of the url rather than hardcoding

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>