### PR TITLE
chore: update aries-framework-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 GOBIN_PATH             = $(abspath .)/build/bin
 ARIES_AGENT_REST_PATH=cmd/agent-rest
 ARIES_AGENT_MOBILE_PATH=cmd/agent-mobile
-ARIES_FRAMEWORK_COMMIT=20fa96607e8faf48c65ac62c7492d58e01e46e95
+ARIES_FRAMEWORK_COMMIT=d14c77b2e8a99888b43a3def74849c91d693ca12
 PROJECT_ROOT = github.com/trustbloc/agent-sdk
 OPENAPI_SPEC_PATH=build/rest/openapi/spec
 OPENAPI_DOCKER_IMG=quay.io/goswagger/swagger

--- a/cmd/agent-js-worker/go.mod
+++ b/cmd/agent-js-worker/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/snappy v0.0.2 // indirect
 	github.com/google/tink/go v1.5.0
 	github.com/google/uuid v1.1.2
-	github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a
+	github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37
 	github.com/hyperledger/aries-framework-go/component/storage/jsindexeddb v0.0.0-20201208011347-35f4bc183acf
 	github.com/jinzhu/copier v0.0.0-20201025035756-632e723a6687 // indirect

--- a/cmd/agent-js-worker/go.sum
+++ b/cmd/agent-js-worker/go.sum
@@ -518,12 +518,16 @@ github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266 h
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a h1:0YDMAxuonicIW4FyQfkAB38Zf83XpnggLgo0rLCsHu4=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9 h1:UHllztcNHODHT4MaL7rv9cAAFGdok6B3a/G69dYMw80=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9/go.mod h1:jWpvVjYk1wETWfVJBII71ta6LusGKbzOkha8TOxeBRM=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20210121210840-ee9984a4579c h1:4KLf7FrV0UCxK61nSEy+apL1BKJYK/SXiZYl4+MW2ps=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20210121210840-ee9984a4579c/go.mod h1:QbfFi1eodurSG8dvhPDWWLrYmNJBrbxeviUnQ/Y1lyo=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37 h1:25yXEZ7X6OT7BfE4HSs5+JVQGv+5P2UdNVvGIOPMpBs=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37/go.mod h1:K+M5o2GqeLx3POTxg4ceNZiGq5PYK1NA2HsZ88DWNFU=
 github.com/hyperledger/aries-framework-go/component/storage/jsindexeddb v0.0.0-20201208011347-35f4bc183acf h1:Ij7hpNBKXGcn+iW7f+87zqfGLZwMfoTOuWsq4KEpN94=
 github.com/hyperledger/aries-framework-go/component/storage/jsindexeddb v0.0.0-20201208011347-35f4bc183acf/go.mod h1:5Dwe/5rCyxqxAeygrilmJ4VpwwrFQlBOvLXvgPEhsdA=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325 h1:CmZ1Z8SxVbNxZPKih/eOY52CsYTuE1qweIMrGS/Zy6E=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=

--- a/cmd/agent-mobile/go.mod
+++ b/cmd/agent-mobile/go.mod
@@ -8,8 +8,9 @@ go 1.15
 
 require (
 	github.com/google/uuid v1.1.2
-	github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a
+	github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325
 	github.com/stretchr/testify v1.6.1
 	github.com/trustbloc/agent-sdk v0.0.0-00010101000000-000000000000
 	nhooyr.io/websocket v1.8.3

--- a/cmd/agent-mobile/go.sum
+++ b/cmd/agent-mobile/go.sum
@@ -511,11 +511,15 @@ github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266 h
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a h1:0YDMAxuonicIW4FyQfkAB38Zf83XpnggLgo0rLCsHu4=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9 h1:UHllztcNHODHT4MaL7rv9cAAFGdok6B3a/G69dYMw80=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9/go.mod h1:jWpvVjYk1wETWfVJBII71ta6LusGKbzOkha8TOxeBRM=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20210121210840-ee9984a4579c h1:4KLf7FrV0UCxK61nSEy+apL1BKJYK/SXiZYl4+MW2ps=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20210121210840-ee9984a4579c/go.mod h1:QbfFi1eodurSG8dvhPDWWLrYmNJBrbxeviUnQ/Y1lyo=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37 h1:25yXEZ7X6OT7BfE4HSs5+JVQGv+5P2UdNVvGIOPMpBs=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37/go.mod h1:K+M5o2GqeLx3POTxg4ceNZiGq5PYK1NA2HsZ88DWNFU=
 github.com/hyperledger/aries-framework-go/component/storage/jsindexeddb v0.0.0-20201208011347-35f4bc183acf/go.mod h1:5Dwe/5rCyxqxAeygrilmJ4VpwwrFQlBOvLXvgPEhsdA=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325 h1:CmZ1Z8SxVbNxZPKih/eOY52CsYTuE1qweIMrGS/Zy6E=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/cmd/agent-mobile/pkg/wrappers/logger/logger.go
+++ b/cmd/agent-mobile/pkg/wrappers/logger/logger.go
@@ -10,7 +10,7 @@ package logger
 import (
 	"fmt"
 
-	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/spi/log"
 
 	"github.com/trustbloc/agent-sdk/cmd/agent-mobile/pkg/api"
 )

--- a/cmd/agent-rest/go.mod
+++ b/cmd/agent-rest/go.mod
@@ -10,16 +10,18 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/golang/snappy v0.0.2 // indirect
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a
+	github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201113155502-c4ba5d2c7c0a
 	github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20201113155502-c4ba5d2c7c0a
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37
 	github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20201208011347-35f4bc183acf
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/trustbloc/agent-sdk v0.0.0-00010101000000-000000000000
+	github.com/trustbloc/edge-core v0.1.6-0.20210127161542-9e174750f523
 )
 
 go 1.15

--- a/cmd/agent-rest/go.sum
+++ b/cmd/agent-rest/go.sum
@@ -534,6 +534,8 @@ github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266 h
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a h1:0YDMAxuonicIW4FyQfkAB38Zf83XpnggLgo0rLCsHu4=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9 h1:UHllztcNHODHT4MaL7rv9cAAFGdok6B3a/G69dYMw80=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9/go.mod h1:jWpvVjYk1wETWfVJBII71ta6LusGKbzOkha8TOxeBRM=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201113155502-c4ba5d2c7c0a h1:RzG6xTcO3FlQzz8VS6dVe7ZlnGiFdSMZlGMxZDITF3c=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201113155502-c4ba5d2c7c0a/go.mod h1:M7/MF6JD45J4CfhiHuO/CSt9ryzQR+ApV3IOAn2HKzo=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20201113155502-c4ba5d2c7c0a h1:hWhe6yhalnMMljeAsi9XYYAjwyNMHb+YhSH3GmC/+rA=
@@ -547,6 +549,8 @@ github.com/hyperledger/aries-framework-go-ext/test/component/storage v0.0.0-2020
 github.com/hyperledger/aries-framework-go/component/storage/jsindexeddb v0.0.0-20201208011347-35f4bc183acf/go.mod h1:5Dwe/5rCyxqxAeygrilmJ4VpwwrFQlBOvLXvgPEhsdA=
 github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20201208011347-35f4bc183acf h1:qxrJBV3cSLz9t7Y0BpCb08ZsIESwuj76bDs5S4dcDrE=
 github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20201208011347-35f4bc183acf/go.mod h1:wPrJOyn6Y3dChvX6xZQZbiqsRqS9zUyoeCO43R7oPUw=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325 h1:CmZ1Z8SxVbNxZPKih/eOY52CsYTuE1qweIMrGS/Zy6E=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/cmd/agent-rest/startcmd/start_test.go
+++ b/cmd/agent-rest/startcmd/start_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/component/storage/leveldb"
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
+	spilog "github.com/hyperledger/aries-framework-go/spi/log"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
@@ -422,27 +423,27 @@ func TestStartCmdWithLogLevel(t *testing.T) {
 	t.Run("validate log level", func(t *testing.T) {
 		err := setLogLevel("DEBUG")
 		require.NoError(t, err)
-		require.Equal(t, log.DEBUG, log.GetLevel(""))
+		require.Equal(t, spilog.DEBUG, log.GetLevel(""))
 
 		err = setLogLevel("WARNING")
 		require.NoError(t, err)
-		require.Equal(t, log.WARNING, log.GetLevel(""))
+		require.Equal(t, spilog.WARNING, log.GetLevel(""))
 
 		err = setLogLevel("CRITICAL")
 		require.NoError(t, err)
-		require.Equal(t, log.CRITICAL, log.GetLevel(""))
+		require.Equal(t, spilog.CRITICAL, log.GetLevel(""))
 
 		err = setLogLevel("ERROR")
 		require.NoError(t, err)
-		require.Equal(t, log.ERROR, log.GetLevel(""))
+		require.Equal(t, spilog.ERROR, log.GetLevel(""))
 
 		err = setLogLevel("INFO")
 		require.NoError(t, err)
-		require.Equal(t, log.INFO, log.GetLevel(""))
+		require.Equal(t, spilog.INFO, log.GetLevel(""))
 
 		err = setLogLevel("")
 		require.NoError(t, err)
-		require.Equal(t, log.INFO, log.GetLevel(""))
+		require.Equal(t, spilog.INFO, log.GetLevel(""))
 
 		err = setLogLevel("INVALID")
 		require.Error(t, err)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.15
 require (
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a
+	github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20210121210840-ee9984a4579c
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37
 	github.com/hyperledger/aries-framework-go/component/storage/jsindexeddb v0.0.0-20201208011347-35f4bc183acf

--- a/go.sum
+++ b/go.sum
@@ -506,12 +506,16 @@ github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266 h
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a h1:0YDMAxuonicIW4FyQfkAB38Zf83XpnggLgo0rLCsHu4=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203173852-ae61c1c2a87a/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9 h1:UHllztcNHODHT4MaL7rv9cAAFGdok6B3a/G69dYMw80=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9/go.mod h1:jWpvVjYk1wETWfVJBII71ta6LusGKbzOkha8TOxeBRM=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20210121210840-ee9984a4579c h1:4KLf7FrV0UCxK61nSEy+apL1BKJYK/SXiZYl4+MW2ps=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20210121210840-ee9984a4579c/go.mod h1:QbfFi1eodurSG8dvhPDWWLrYmNJBrbxeviUnQ/Y1lyo=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37 h1:25yXEZ7X6OT7BfE4HSs5+JVQGv+5P2UdNVvGIOPMpBs=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37/go.mod h1:K+M5o2GqeLx3POTxg4ceNZiGq5PYK1NA2HsZ88DWNFU=
 github.com/hyperledger/aries-framework-go/component/storage/jsindexeddb v0.0.0-20201208011347-35f4bc183acf h1:Ij7hpNBKXGcn+iW7f+87zqfGLZwMfoTOuWsq4KEpN94=
 github.com/hyperledger/aries-framework-go/component/storage/jsindexeddb v0.0.0-20201208011347-35f4bc183acf/go.mod h1:5Dwe/5rCyxqxAeygrilmJ4VpwwrFQlBOvLXvgPEhsdA=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325 h1:CmZ1Z8SxVbNxZPKih/eOY52CsYTuE1qweIMrGS/Zy6E=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=


### PR DESCRIPTION
* Support for Aries RFC0360: hyperledger/aries-framework-go#2526
* Logging packages have been refactored

Signed-off-by: George Aristy <george.aristy@securekey.com>