### PR TITLE
perf: preload data for secp256k1 curve upon agent startup

### DIFF
--- a/cmd/agent-js-worker/go.mod
+++ b/cmd/agent-js-worker/go.mod
@@ -7,7 +7,7 @@ module github.com/trustbloc/agent-sdk/cmd/agent-js-worker
 go 1.15
 
 require (
-	github.com/btcsuite/btcd v0.21.0-beta // indirect
+	github.com/btcsuite/btcd v0.21.0-beta
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/golang/snappy v0.0.2 // indirect
 	github.com/google/tink/go v1.5.0


### PR DESCRIPTION
This PR adds the code that triggers `btcec.S256()` upon the agent startup. It should cut around 300ms from the execution of the didexchange protocol during establishing a connection to the mediator.

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>