### PR TITLE
feat: Wallet SDK - support for credential manifest & metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 GOBIN_PATH             = $(abspath .)/build/bin
 ARIES_AGENT_REST_PATH=cmd/agent-rest
 ARIES_AGENT_MOBILE_PATH=cmd/agent-mobile
-ARIES_FRAMEWORK_COMMIT=6041c17d6e599a8000eb546fd8ab9a5189e598af
+ARIES_FRAMEWORK_COMMIT=bb5bedb39f3610a362829bb0b79b8ad2aca71b72
 PROJECT_ROOT = github.com/trustbloc/agent-sdk
 OPENAPI_SPEC_PATH=build/rest/openapi/spec
 OPENAPI_DOCKER_IMG=quay.io/goswagger/swagger

--- a/cmd/agent-js-worker/go.mod
+++ b/cmd/agent-js-worker/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/btcsuite/btcd v0.22.0-beta
 	github.com/google/tink/go v1.6.1-0.20210519071714-58be99b3c4d0
 	github.com/google/uuid v1.3.0
-	github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59
+	github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.1.4-0.20220114172935-0e96d787f80f
-	github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220126164804-6041c17d6e59
-	github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220126164804-6041c17d6e59
-	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59
+	github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220202170435-bb5bedb39f36
+	github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220202170435-bb5bedb39f36
+	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/piprate/json-gold v0.4.1-0.20210813112359-33b90c4ca86c
 	github.com/stretchr/testify v1.7.0

--- a/cmd/agent-js-worker/go.sum
+++ b/cmd/agent-js-worker/go.sum
@@ -747,8 +747,8 @@ github.com/hyperledger/aries-framework-go v0.1.8-0.20211201185059-733a3370f501/g
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211216162950-a0879ff5e52a/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211217135421-f68d5698237a/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
-github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59 h1:nKA64Ex2UuHvN3n+bYTki5pAkqSRYxfPU2PaWu3D60A=
-github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
+github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36 h1:LhpKD6oZCKwTdG2PLwv2BSYbAEv+8CNyISF0EWOyhm8=
+github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:FtlFhPHMyLORgrPpvWSmEQSNhLiwAQ4V6rqNPfuDj0o=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:aiO9mXZBykIEwmgp9sSdpMuTw0P7b+ZFUltcIB9ZccY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc h1:VI3JX0ymIkI5amU2sKP+25EuopLjkDvUHfmJ/jsPFK0=
@@ -762,10 +762,10 @@ github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-2021
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:7D+Y5J9cIsUrMGFAsIED+3bAPNjxp6ggXo0/kT5N6BI=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:00tdiDIlEdmcLuN/5zSr3NI8AycnvRMMt4M07VSqiqw=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210820175050-dcc7a225178d/go.mod h1:i40JkMHCh9cHHxSc1SYznO3xDH6ly5CE0B3vPYZVeWI=
-github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220126164804-6041c17d6e59 h1:2XkOf+kUP36QD5hd4PRh7rBBOpIrQkeyH6KGVetSUQc=
-github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220126164804-6041c17d6e59/go.mod h1:YXPlzNCRaDHQaDAi1pGYs9sV1JhhRfXwSmqVFedduhY=
-github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220126164804-6041c17d6e59 h1:ve9K4QK1365Lv/kDiZTtkLgdX1baG7oHrc4bC0CXBDU=
-github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220126164804-6041c17d6e59/go.mod h1:57n+xmBP9rDI3ZhgreKCi+4dZpPRl8QgHK29kR3cdPM=
+github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220202170435-bb5bedb39f36 h1:Fygm37KnuBHvsk7MMR8RRUEQliPm268RYeHwUwbw4l8=
+github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:YXPlzNCRaDHQaDAi1pGYs9sV1JhhRfXwSmqVFedduhY=
+github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220202170435-bb5bedb39f36 h1:hVPtkaSfbC6DYOk9zec9nlM3W9rzQis8gzTVXcjHv0w=
+github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:57n+xmBP9rDI3ZhgreKCi+4dZpPRl8QgHK29kR3cdPM=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210320144851-40976de98ccf/go.mod h1:HVV8sifdHIyLkrlgmK/6+3YWKnOJPUfoNU+4SwQqMSs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:kJT7bcaKsvk1lMp2jqS8srF+ZUie2H4MoPbL2V29dgA=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:uGc7F3tXQIY6xjs8VEI6/oxp4ZDXDfGjPMCTgax5Zhc=
@@ -775,8 +775,8 @@ github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-202106032
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:k8CjDLBLxygTEj3D077OeH4SJsVE3mK60AyeO/C9sxs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210820175050-dcc7a225178d/go.mod h1:wdgGPwXzih+QD2Q4nvMnGO0dm0D0rxmzQcSNLcW6fcg=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210910143505-343c246c837c/go.mod h1:bFeSTLeQktv7TrPVaxeKE7H6E3dVBAG29ezdDS1Eyu0=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59 h1:3CJUAVUj3FxQvWN55ZFnv7XzXqyYgI3O+vIyg3J4DoY=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59/go.mod h1:yLgRpVlZ2heeeOpTgvEnG/yHL9q1keUu5ILQ6s2qpLU=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36 h1:vtnI3aDZbg6jN443TROvzhaZhUFMGwFoyE8lCF6VN6Q=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:yLgRpVlZ2heeeOpTgvEnG/yHL9q1keUu5ILQ6s2qpLU=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210310001230-bc1bd8ea889c/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210310160016-d5eea2ecdd50/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
@@ -798,8 +798,8 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20210902194940-97c6f2cded6c
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210909135806-a1c268dfb633/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20211203210130-e927c9ed581a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20211206182816-9cdcbcd09dc2/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59 h1:cYgM+V8mJi5sZi+fbL8/77MLf8jGXtpgNza4t3gyVbs=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36 h1:FrvS7pxk4dRQi+IvKlmavcDHJccclQWvryoQb3OhLnk=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210310160016-d5eea2ecdd50/go.mod h1:AybsT4/saiuxdVhK5CgOLIkcNMPZtX3GAUMOjHcLLjk=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:JHzDtgJLd0134iLFXLxGBjJF+Z+TgiElA/5oVgMazts=

--- a/cmd/agent-js-worker/src/agent-rest-client.js
+++ b/cmd/agent-js-worker/src/agent-rest-client.js
@@ -547,6 +547,10 @@ const pkgs = {
             path: "/vcwallet/request-credential",
             method: "POST",
         },
+        ResolveCredentialManifest: {
+            path: "/vcwallet/resolve-credential-manifest",
+            method: "POST",
+        },
     },
     didclient: {
         CreateOrbDID: {

--- a/cmd/agent-js-worker/src/agent.js
+++ b/cmd/agent-js-worker/src/agent.js
@@ -1453,6 +1453,19 @@ const Agent = function (opts) {
             requestCredential: async function (req) {
                 return invoke(aw, pending, this.pkgname, "RequestCredential", req, "timeout while performing request credential from wallet")
             },
+
+            /**
+             *
+             * ResolveCredentialManifest resolves given credential manifest by credential fulfillment or credential.
+             * Supports: https://identity.foundation/credential-manifest/
+             *
+             *  Returns resolved descriptors.
+             *
+             * @returns {Promise<Object>}
+             */
+            resolveCredentialManifest: async function (req) {
+                return invoke(aw, pending, this.pkgname, "ResolveCredentialManifest", req, "timeout while resolving credential manifest from wallet")
+            },
         },
         /**
          * DIDClient methods

--- a/cmd/agent-js-worker/src/wasm_exec.js
+++ b/cmd/agent-js-worker/src/wasm_exec.js
@@ -296,8 +296,8 @@
 						setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000);
 					},
 
-					// func walltime() (sec int64, nsec int32)
-					"runtime.walltime": (sp) => {
+					// func walltime1() (sec int64, nsec int32)
+					"runtime.walltime1": (sp) => {
 						sp >>>= 0;
 						const msec = (new Date).getTime();
 						setInt64(sp + 8, msec / 1000);
@@ -401,7 +401,6 @@
 							storeValue(sp + 56, result);
 							this.mem.setUint8(sp + 64, 1);
 						} catch (err) {
-							sp = this._inst.exports.getsp() >>> 0; // see comment above
 							storeValue(sp + 56, err);
 							this.mem.setUint8(sp + 64, 0);
 						}
@@ -418,7 +417,6 @@
 							storeValue(sp + 40, result);
 							this.mem.setUint8(sp + 48, 1);
 						} catch (err) {
-							sp = this._inst.exports.getsp() >>> 0; // see comment above
 							storeValue(sp + 40, err);
 							this.mem.setUint8(sp + 48, 0);
 						}
@@ -435,7 +433,6 @@
 							storeValue(sp + 40, result);
 							this.mem.setUint8(sp + 48, 1);
 						} catch (err) {
-							sp = this._inst.exports.getsp() >>> 0; // see comment above
 							storeValue(sp + 40, err);
 							this.mem.setUint8(sp + 48, 0);
 						}
@@ -566,13 +563,6 @@
 				this.mem.setUint32(offset + 4, 0, true);
 				offset += 8;
 			});
-
-			// The linker guarantees global data starts from at least wasmMinDataAddr.
-			// Keep in sync with cmd/link/internal/ld/data.go:wasmMinDataAddr.
-			const wasmMinDataAddr = 4096 + 8192;
-			if (offset >= wasmMinDataAddr) {
-				throw new Error("total length of command line and environment variables exceeds limit");
-			}
 
 			this._inst.exports.run(argc, argv);
 			if (this.exited) {

--- a/cmd/agent-mobile/go.mod
+++ b/cmd/agent-mobile/go.mod
@@ -8,11 +8,11 @@ go 1.17
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59
+	github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.1.4-0.20220114172935-0e96d787f80f
-	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220126164804-6041c17d6e59
+	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220202170435-bb5bedb39f36
 	github.com/piprate/json-gold v0.4.1-0.20210813112359-33b90c4ca86c
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/agent-sdk v0.0.0-00010101000000-000000000000

--- a/cmd/agent-mobile/go.sum
+++ b/cmd/agent-mobile/go.sum
@@ -746,8 +746,8 @@ github.com/hyperledger/aries-framework-go v0.1.8-0.20211201185059-733a3370f501/g
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211216162950-a0879ff5e52a/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211217135421-f68d5698237a/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
-github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59 h1:nKA64Ex2UuHvN3n+bYTki5pAkqSRYxfPU2PaWu3D60A=
-github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
+github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36 h1:LhpKD6oZCKwTdG2PLwv2BSYbAEv+8CNyISF0EWOyhm8=
+github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:FtlFhPHMyLORgrPpvWSmEQSNhLiwAQ4V6rqNPfuDj0o=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:aiO9mXZBykIEwmgp9sSdpMuTw0P7b+ZFUltcIB9ZccY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc h1:VI3JX0ymIkI5amU2sKP+25EuopLjkDvUHfmJ/jsPFK0=
@@ -763,7 +763,7 @@ github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-202108071
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210820175050-dcc7a225178d/go.mod h1:i40JkMHCh9cHHxSc1SYznO3xDH6ly5CE0B3vPYZVeWI=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20211214153431-5c8a10d6e6ad h1:z2ojC1qLYJbXl39VxM6A6bEYx3t1sLP6v2hV50eI0NM=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20211214153431-5c8a10d6e6ad/go.mod h1:YXPlzNCRaDHQaDAi1pGYs9sV1JhhRfXwSmqVFedduhY=
-github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220126164804-6041c17d6e59/go.mod h1:57n+xmBP9rDI3ZhgreKCi+4dZpPRl8QgHK29kR3cdPM=
+github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:57n+xmBP9rDI3ZhgreKCi+4dZpPRl8QgHK29kR3cdPM=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210320144851-40976de98ccf/go.mod h1:HVV8sifdHIyLkrlgmK/6+3YWKnOJPUfoNU+4SwQqMSs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:kJT7bcaKsvk1lMp2jqS8srF+ZUie2H4MoPbL2V29dgA=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:uGc7F3tXQIY6xjs8VEI6/oxp4ZDXDfGjPMCTgax5Zhc=
@@ -773,8 +773,8 @@ github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-202106032
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:k8CjDLBLxygTEj3D077OeH4SJsVE3mK60AyeO/C9sxs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210820175050-dcc7a225178d/go.mod h1:wdgGPwXzih+QD2Q4nvMnGO0dm0D0rxmzQcSNLcW6fcg=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210910143505-343c246c837c/go.mod h1:bFeSTLeQktv7TrPVaxeKE7H6E3dVBAG29ezdDS1Eyu0=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59 h1:3CJUAVUj3FxQvWN55ZFnv7XzXqyYgI3O+vIyg3J4DoY=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59/go.mod h1:yLgRpVlZ2heeeOpTgvEnG/yHL9q1keUu5ILQ6s2qpLU=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36 h1:vtnI3aDZbg6jN443TROvzhaZhUFMGwFoyE8lCF6VN6Q=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:yLgRpVlZ2heeeOpTgvEnG/yHL9q1keUu5ILQ6s2qpLU=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210310001230-bc1bd8ea889c/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210310160016-d5eea2ecdd50/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
@@ -796,8 +796,8 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20210902194940-97c6f2cded6c
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210909135806-a1c268dfb633/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20211203210130-e927c9ed581a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20211206182816-9cdcbcd09dc2/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59 h1:cYgM+V8mJi5sZi+fbL8/77MLf8jGXtpgNza4t3gyVbs=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36 h1:FrvS7pxk4dRQi+IvKlmavcDHJccclQWvryoQb3OhLnk=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210310160016-d5eea2ecdd50/go.mod h1:AybsT4/saiuxdVhK5CgOLIkcNMPZtX3GAUMOjHcLLjk=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:JHzDtgJLd0134iLFXLxGBjJF+Z+TgiElA/5oVgMazts=
@@ -809,8 +809,8 @@ github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820153043-8
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d/go.mod h1:7jEZdg455syX4f+ozLgwhYfIuiEQ/TgdIoOyALMwPG0=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210909135806-a1c268dfb633/go.mod h1:XtAqwhIKA5tWOiWX/wZEFeANNGnRyQL6CNIIeE3lAVc=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20211204013109-366f6ef74861/go.mod h1:UPbljMgUwdph/L36m8LrFxnZ4UP32pXeJ/GfluusI3c=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220126164804-6041c17d6e59 h1:PUTZVMcIVRbjIPp4NLSQF6q4V7Qz2ejegjcpnLd31D8=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220126164804-6041c17d6e59/go.mod h1:HojN6OAh8ZtXBe5X2arcSOe1SLo5Dsjqto8ICjSLQ2g=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220202170435-bb5bedb39f36 h1:sUyIQUPuk8ZaxgN3KnB+28AeyLwUfCn7pMwthMl+tjE=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:HojN6OAh8ZtXBe5X2arcSOe1SLo5Dsjqto8ICjSLQ2g=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=

--- a/cmd/agent-rest/go.mod
+++ b/cmd/agent-rest/go.mod
@@ -9,14 +9,14 @@ go 1.17
 require (
 	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59
+	github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22
 	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc
 	github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20210909220549-ce3a2ee13e22
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.1.4-0.20220114172935-0e96d787f80f
-	github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20220126164804-6041c17d6e59
-	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59
+	github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20220202170435-bb5bedb39f36
+	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0

--- a/cmd/agent-rest/go.sum
+++ b/cmd/agent-rest/go.sum
@@ -758,8 +758,8 @@ github.com/hyperledger/aries-framework-go v0.1.8-0.20211201185059-733a3370f501/g
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211216162950-a0879ff5e52a/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211217135421-f68d5698237a/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
-github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59 h1:nKA64Ex2UuHvN3n+bYTki5pAkqSRYxfPU2PaWu3D60A=
-github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
+github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36 h1:LhpKD6oZCKwTdG2PLwv2BSYbAEv+8CNyISF0EWOyhm8=
+github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22 h1:dzRPCOUIU/RKlGSGJsqpBh0uHOjMN4LC/c25fs7nnlE=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:FtlFhPHMyLORgrPpvWSmEQSNhLiwAQ4V6rqNPfuDj0o=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:aiO9mXZBykIEwmgp9sSdpMuTw0P7b+ZFUltcIB9ZccY=
@@ -777,9 +777,9 @@ github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-202108071
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210820175050-dcc7a225178d/go.mod h1:i40JkMHCh9cHHxSc1SYznO3xDH6ly5CE0B3vPYZVeWI=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20211214153431-5c8a10d6e6ad h1:z2ojC1qLYJbXl39VxM6A6bEYx3t1sLP6v2hV50eI0NM=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20211214153431-5c8a10d6e6ad/go.mod h1:YXPlzNCRaDHQaDAi1pGYs9sV1JhhRfXwSmqVFedduhY=
-github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220126164804-6041c17d6e59/go.mod h1:57n+xmBP9rDI3ZhgreKCi+4dZpPRl8QgHK29kR3cdPM=
-github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20220126164804-6041c17d6e59 h1:sEujy5Q4+x4Tk2Ba1sS+fRsQKwm401UhekQjUwDa1j0=
-github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20220126164804-6041c17d6e59/go.mod h1:8bMn7oMJfLd4Gd3LoxhxY5/3KjbsXcJAFvF15tpBxis=
+github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:57n+xmBP9rDI3ZhgreKCi+4dZpPRl8QgHK29kR3cdPM=
+github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20220202170435-bb5bedb39f36 h1:9Taf8Dah04ukh1k6Rr5R1TSQHBxtmurNSYoEAqPxrhU=
+github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:8bMn7oMJfLd4Gd3LoxhxY5/3KjbsXcJAFvF15tpBxis=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210320144851-40976de98ccf/go.mod h1:HVV8sifdHIyLkrlgmK/6+3YWKnOJPUfoNU+4SwQqMSs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:kJT7bcaKsvk1lMp2jqS8srF+ZUie2H4MoPbL2V29dgA=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:uGc7F3tXQIY6xjs8VEI6/oxp4ZDXDfGjPMCTgax5Zhc=
@@ -789,8 +789,8 @@ github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-202106032
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:k8CjDLBLxygTEj3D077OeH4SJsVE3mK60AyeO/C9sxs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210820175050-dcc7a225178d/go.mod h1:wdgGPwXzih+QD2Q4nvMnGO0dm0D0rxmzQcSNLcW6fcg=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210910143505-343c246c837c/go.mod h1:bFeSTLeQktv7TrPVaxeKE7H6E3dVBAG29ezdDS1Eyu0=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59 h1:3CJUAVUj3FxQvWN55ZFnv7XzXqyYgI3O+vIyg3J4DoY=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59/go.mod h1:yLgRpVlZ2heeeOpTgvEnG/yHL9q1keUu5ILQ6s2qpLU=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36 h1:vtnI3aDZbg6jN443TROvzhaZhUFMGwFoyE8lCF6VN6Q=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:yLgRpVlZ2heeeOpTgvEnG/yHL9q1keUu5ILQ6s2qpLU=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210310001230-bc1bd8ea889c/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210310160016-d5eea2ecdd50/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
@@ -812,8 +812,8 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20210902194940-97c6f2cded6c
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210909135806-a1c268dfb633/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20211203210130-e927c9ed581a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20211206182816-9cdcbcd09dc2/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59 h1:cYgM+V8mJi5sZi+fbL8/77MLf8jGXtpgNza4t3gyVbs=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36 h1:FrvS7pxk4dRQi+IvKlmavcDHJccclQWvryoQb3OhLnk=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210310160016-d5eea2ecdd50/go.mod h1:AybsT4/saiuxdVhK5CgOLIkcNMPZtX3GAUMOjHcLLjk=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:JHzDtgJLd0134iLFXLxGBjJF+Z+TgiElA/5oVgMazts=

--- a/cmd/wallet-js-sdk/docs/wallet_sdk.md
+++ b/cmd/wallet-js-sdk/docs/wallet_sdk.md
@@ -73,6 +73,11 @@ Refer  Wallet SDK Data Model [documentation](data_models.md) to know about data 
  Supporting Attachment Format from DIDComm V1.</p>
 <p> Note: Currently finding only one attachment per format.</p>
 </dd>
+<dt><a href="#findAttachmentByFormatV2">findAttachmentByFormatV2</a></dt>
+<dd><p>Finds attachment by given format.
+ Supporting Attachment Format from DIDComm V2.</p>
+<p> Note: Currently finding only one attachment per format.</p>
+</dd>
 <dt><a href="#extractOOBGoalCode">extractOOBGoalCode</a></dt>
 <dd><p>Reads out-of-band invitation goal code.
  Supports DIDComm V1 &amp; V2</p>
@@ -190,6 +195,12 @@ credential module provides wallet credential handling features,
     * [.exports.CredentialManager](#exp_module_credential--exports.CredentialManager) ⏏
         * [new exports.CredentialManager(agent, user)](#new_module_credential--exports.CredentialManager_new)
         * [.save(auth, contents, options)](#module_credential--exports.CredentialManager.CredentialManager+save) ⇒ <code>Promise.&lt;Object&gt;</code>
+        * [.saveCredentialManifest(auth, contents)](#module_credential--exports.CredentialManager.CredentialManager+saveCredentialManifest) ⇒ <code>Promise.&lt;Object&gt;</code>
+        * [.saveCredentialMetadata(auth, options)](#module_credential--exports.CredentialManager.CredentialManager+saveCredentialMetadata) ⇒ <code>Promise.&lt;Object&gt;</code>
+        * [.getCredentialMetadata(auth, id, options)](#module_credential--exports.CredentialManager.CredentialManager+getCredentialMetadata) ⇒ <code>Promise.&lt;Object&gt;</code>
+        * [.getAllCredentialMetadata(auth, options)](#module_credential--exports.CredentialManager.CredentialManager+getAllCredentialMetadata) ⇒ <code>Promise.&lt;Object&gt;</code>
+        * [.updateCredentialMetadata(auth, id, options)](#module_credential--exports.CredentialManager.CredentialManager+updateCredentialMetadata) ⇒ <code>Promise.&lt;Object&gt;</code>
+        * [.resolveManifest(auth, options)](#module_credential--exports.CredentialManager.CredentialManager+resolveManifest) ⇒ <code>Promise.&lt;Object&gt;</code>
         * [.get(auth, contentID)](#module_credential--exports.CredentialManager.CredentialManager+get) ⇒ <code>Promise.&lt;Object&gt;</code>
         * [.getAll(auth)](#module_credential--exports.CredentialManager.CredentialManager+getAll) ⇒ <code>Promise.&lt;Object&gt;</code>
         * [.remove(auth, contentID)](#module_credential--exports.CredentialManager.CredentialManager+remove) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -198,9 +209,9 @@ credential module provides wallet credential handling features,
         * [.verify(auth, verificationOption)](#module_credential--exports.CredentialManager.CredentialManager+verify) ⇒ <code>Promise.&lt;Object&gt;</code>
         * [.derive(auth, credentialOption, deriveOption)](#module_credential--exports.CredentialManager.CredentialManager+derive) ⇒ <code>Promise.&lt;Object&gt;</code>
         * [.query(auth, query)](#module_credential--exports.CredentialManager.CredentialManager+query) ⇒ <code>Promise.&lt;Object&gt;</code>
-        * [.saveManifestCredential(auth, manifest, connectionID)](#module_credential--exports.CredentialManager.CredentialManager+saveManifestCredential) ⇒ <code>Promise.&lt;Object&gt;</code>
+        * [.saveManifestVC(auth, manifest, connectionID)](#module_credential--exports.CredentialManager.CredentialManager+saveManifestVC) ⇒ <code>Promise.&lt;Object&gt;</code>
         * [.getManifestConnection(auth, manifestCredID)](#module_credential--exports.CredentialManager.CredentialManager+getManifestConnection) ⇒ <code>Promise.&lt;String&gt;</code>
-        * [.getAllManifests(auth)](#module_credential--exports.CredentialManager.CredentialManager+getAllManifests) ⇒ <code>Promise.&lt;Object&gt;</code>
+        * [.getAllManifestVCs(auth)](#module_credential--exports.CredentialManager.CredentialManager+getAllManifestVCs) ⇒ <code>Promise.&lt;Object&gt;</code>
 
 <a name="exp_module_credential--exports.CredentialManager"></a>
 
@@ -222,7 +233,7 @@ credential module provides wallet credential handling features,
 <a name="module_credential--exports.CredentialManager.CredentialManager+save"></a>
 
 #### exports.CredentialManager.save(auth, contents, options) ⇒ <code>Promise.&lt;Object&gt;</code>
-Saves given credential into wallet content store.
+Saves given credential into wallet content store along with credential metadata & manifest details along with saved credential.
 
 **Kind**: instance method of [<code>exports.CredentialManager</code>](#exp_module_credential--exports.CredentialManager)  
 **Returns**: <code>Promise.&lt;Object&gt;</code> - - empty promise or error if operation fails.  
@@ -231,12 +242,112 @@ Saves given credential into wallet content store.
 | --- | --- | --- |
 | auth | <code>string</code> | authorization token for wallet operations. |
 | contents | <code>Object</code> | credential(s) to be saved in wallet content store. |
-| contents.credential | <code>Object</code> | credential to be saved in wallet content store. |
 | contents.credentials | <code>Array.&lt;Object&gt;</code> | array of credentials to be saved in wallet content store. |
-| contents.presentation | <code>Object</code> | presentation from which all the credentials to be saved in wallet content store. |
+| contents.presentation | <code>Object</code> | presentation from which all the credentials to be saved in wallet content store.  If credential fulfillment presentation is provided then no need to supply descriptor map along with manifest.  Refer @see [Credential Fulfillment](https://identity.foundation/credential-manifest/#credential-fulfillment) for more details. |
 | options | <code>Object</code> | options for saving credential. |
 | options.verify | <code>boolean</code> | (optional) to verify credential before save. |
 | options.collection | <code>String</code> | (optional) ID of the wallet collection to which the credential should belong. |
+| options.manifest | <code>String</code> | (required) credential manifest of the credential being saved.  Refer @see [Credential Manifest](https://identity.foundation/credential-manifest/#credential-manifest-2) for more details. |
+
+<a name="module_credential--exports.CredentialManager.CredentialManager+saveCredentialManifest"></a>
+
+#### exports.CredentialManager.saveCredentialManifest(auth, contents) ⇒ <code>Promise.&lt;Object&gt;</code>
+Saves credential manifest into wallet content store.
+
+**Kind**: instance method of [<code>exports.CredentialManager</code>](#exp_module_credential--exports.CredentialManager)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - - empty promise or error if operation fails.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| auth | <code>string</code> | authorization token for wallet operations. |
+| contents | <code>Object</code> | credential manifest data model.  Refer @see [Credential Manifest](https://identity.foundation/credential-manifest/#credential-manifest-2) for more details. |
+
+<a name="module_credential--exports.CredentialManager.CredentialManager+saveCredentialMetadata"></a>
+
+#### exports.CredentialManager.saveCredentialMetadata(auth, options) ⇒ <code>Promise.&lt;Object&gt;</code>
+Reads credential metadata and saves credential metadata data model into wallet content store.
+
+**Kind**: instance method of [<code>exports.CredentialManager</code>](#exp_module_credential--exports.CredentialManager)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - - empty promise or error if operation fails.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| auth | <code>string</code> | authorization token for wallet operations. |
+| options | <code>Object</code> | subjects from which credential metadata will be extracted. |
+| options.credential | <code>Object</code> | credential data model from which basic credential attributes like type, issuer, expiration etc will be read. |
+| options.manifestID | <code>String</code> | ID of the credential manifest of the given credential |
+| options.descriptorID | <code>String</code> | ID of the credential manifest output descriptor of the given credential. |
+| options.collection | <code>String</code> | (optional) ID of the collection to which this credential belongs. |
+
+<a name="module_credential--exports.CredentialManager.CredentialManager+getCredentialMetadata"></a>
+
+#### exports.CredentialManager.getCredentialMetadata(auth, id, options) ⇒ <code>Promise.&lt;Object&gt;</code>
+Gets credential metadata from wallet content store and also optionally resolves credential data using credential manifest.
+
+**Kind**: instance method of [<code>exports.CredentialManager</code>](#exp_module_credential--exports.CredentialManager)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - - promise containing credential metadata or error if operation fails.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| auth | <code>String</code> | authorization token for wallet operations. |
+| id | <code>String</code> | credential ID. |
+| options | <code>Object</code> | options to get credential metadata |
+| options.resolve | <code>Bool</code> | (optional) if true then resolves credential manifest of the given credential using descriptor info found in credential metadata. |
+
+<a name="module_credential--exports.CredentialManager.CredentialManager+getAllCredentialMetadata"></a>
+
+#### exports.CredentialManager.getAllCredentialMetadata(auth, options) ⇒ <code>Promise.&lt;Object&gt;</code>
+Gets all credential metadata from wallet content store and also optionally resolves credential using respective credential metadata info.
+
+**Kind**: instance method of [<code>exports.CredentialManager</code>](#exp_module_credential--exports.CredentialManager)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - - promise containing list of credential metadata or error if operation fails.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| auth | <code>String</code> | authorization token for wallet operations. |
+| options | <code>Object</code> | options to get all credential metadata. |
+| options.credentialIDs | <code>Bool</code> | (optional) filters credential metadata by given credential IDs. |
+| options.collection | <code>String</code> | (optional) filters credential metadata by given collection ID. |
+| options.resolve | <code>Bool</code> | (optional) if true then resolves credential manifest of the given credential using descriptor info found in credential metadata. |
+
+<a name="module_credential--exports.CredentialManager.CredentialManager+updateCredentialMetadata"></a>
+
+#### exports.CredentialManager.updateCredentialMetadata(auth, id, options) ⇒ <code>Promise.&lt;Object&gt;</code>
+Updates credential metadata. Currently supporting updating only credential name and description fields.
+
+**Kind**: instance method of [<code>exports.CredentialManager</code>](#exp_module_credential--exports.CredentialManager)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - - empty promise or error if operation fails.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| auth | <code>String</code> | authorization token for wallet operations. |
+| id | <code>String</code> | ID of the credential metadata to be updated. |
+| options | <code>Object</code> | options to update credential metadata. |
+| options.name | <code>String</code> | (optional) name attribute of the credential metadata to be updated. |
+| options.description | <code>String</code> | (optional) description attribute of the credential metadata to be updated. |
+| options.collection | <code>String</code> | (optional) ID  of the collection to which this credential metadata to be updated. |
+
+<a name="module_credential--exports.CredentialManager.CredentialManager+resolveManifest"></a>
+
+#### exports.CredentialManager.resolveManifest(auth, options) ⇒ <code>Promise.&lt;Object&gt;</code>
+Resolves credential by credential manifest, descriptor or fulfillment.
+
+Given credential can be resolved by raw credential, ID of the credential saved in wallet, credential fulfillment,
+ID of the manifest saved in wallet, raw credential manifest, output descriptor of the manifest etc
+
+**Kind**: instance method of [<code>exports.CredentialManager</code>](#exp_module_credential--exports.CredentialManager)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - - promise containing resolved results or error if operation fails.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| auth | <code>String</code> | authorization token for wallet operations. |
+| options | <code>Object</code> | options to resolve credential from wallet. |
+| options.credentialID | <code>String</code> | (optional) ID of the credential to be resolved from wallet content store. |
+| options.credential | <code>String</code> | (optional) raw credential data model to be resolved. |
+| options.fulfillment | <code>String</code> | (optional) credential fulfillment using which given raw credential or credential ID to be resolved. |
+| options.manifestID | <code>String</code> | (optional) ID of the manifest from wallet content store. |
+| options.manifest | <code>String</code> | (optional) raw manifest to be used for resolving credential. |
+| options.descriptorID | <code>String</code> | (optional) if fulfillment not provided then this descriptor ID can be used to resolve credential. Refer @see [Credential Manifest Specifications](https://identity.foundation/credential-manifest/) for more details. |
 
 <a name="module_credential--exports.CredentialManager.CredentialManager+get"></a>
 
@@ -266,7 +377,9 @@ Gets All credentials from wallet.
 <a name="module_credential--exports.CredentialManager.CredentialManager+remove"></a>
 
 #### exports.CredentialManager.remove(auth, contentID) ⇒ <code>Promise.&lt;Object&gt;</code>
-Removes credential from wallet
+Removes credential and its metadata from wallet.
+
+ Doesn't delete respective credential manifest since one credential manifest can be referred by many other credentials too.
 
 **Kind**: instance method of [<code>exports.CredentialManager</code>](#exp_module_credential--exports.CredentialManager)  
 **Returns**: <code>Promise.&lt;Object&gt;</code> - - empty promise or an error if operation fails.  
@@ -368,13 +481,14 @@ runs credential queries in wallet.
 | auth | <code>String</code> | authorization token for performing this wallet operation. |
 | query | <code>Object</code> | list of credential queries, any types of supported query types can be mixed. |
 
-<a name="module_credential--exports.CredentialManager.CredentialManager+saveManifestCredential"></a>
+<a name="module_credential--exports.CredentialManager.CredentialManager+saveManifestVC"></a>
 
-#### exports.CredentialManager.saveManifestCredential(auth, manifest, connectionID) ⇒ <code>Promise.&lt;Object&gt;</code>
+#### exports.CredentialManager.saveManifestVC(auth, manifest, connectionID) ⇒ <code>Promise.&lt;Object&gt;</code>
 saves manifest credential along with its mapping to given connection ID.
 
 **Kind**: instance method of [<code>exports.CredentialManager</code>](#exp_module_credential--exports.CredentialManager)  
 **Returns**: <code>Promise.&lt;Object&gt;</code> - - empty promise or an error if operation fails.  
+**Deprecated,**: to be used for DIDComm blinded routing flow only  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -395,9 +509,9 @@ Returns connection ID mapped to given manifest credential ID.
 | auth | <code>String</code> | authorization token for performing this wallet operation. |
 | manifestCredID | <code>String</code> | ID of manifest credential. |
 
-<a name="module_credential--exports.CredentialManager.CredentialManager+getAllManifests"></a>
+<a name="module_credential--exports.CredentialManager.CredentialManager+getAllManifestVCs"></a>
 
-#### exports.CredentialManager.getAllManifests(auth) ⇒ <code>Promise.&lt;Object&gt;</code>
+#### exports.CredentialManager.getAllManifestVCs(auth) ⇒ <code>Promise.&lt;Object&gt;</code>
 Gets all manifest credentials saved in wallet.
 
 **Kind**: instance method of [<code>exports.CredentialManager</code>](#exp_module_credential--exports.CredentialManager)  
@@ -520,7 +634,9 @@ Creates Orb DID and saves it in wallet content store.
 | auth | <code>string</code> |  | authorization token for wallet operations. |
 | options | <code>Object</code> |  | options for creating Orb DID. |
 | options.keyType | <code>Object</code> | <code>ED25519</code> | (optional, default ED25519) type of the key to be used for creating keys for the DID, Refer agent documentation for supported key types. |
+| options.keyAgreementKeyType | <code>Object</code> | <code>X25519ECDHKW</code> | (optional, default X25519ECDHKW) type of the key to be used for creating keyAgreements for the DID, Refer agent documentation for supported key types. |
 | options.signatureType | <code>String</code> | <code>Ed25519VerificationKey2018</code> | (optional, default Ed25519VerificationKey2018) signature type to be used for DID verification methods. |
+| options.keyAgreementType | <code>String</code> | <code>X25519KeyAgreementKey2019</code> | (optional, default X25519KeyAgreementKey2019) keyAgreement VM type to be used for DID key agreement (payload encryption). For JWK type, use `JsonWebKey2020`. |
 | options.purposes | <code>Array.&lt;String&gt;</code> | <code>authentication</code> | (optional, default "authentication") purpose of the key. |
 | options.collection | <code>String</code> |  | (optional, default no collection) collection to which this DID should belong in wallet content store. |
 
@@ -665,7 +781,9 @@ didcomm module provides wallet based DIDComm features.
         * _static_
             * [.createInvitationFromRouter](#module_didcomm--exports.DIDComm.createInvitationFromRouter)
             * [.getMediatorConnections(agent)](#module_didcomm--exports.DIDComm.getMediatorConnections)
-            * [.connectToMediator(agent, endpoint, wait)](#module_didcomm--exports.DIDComm.connectToMediator)
+            * [.connectToMediator(agent, endpoint, waitForStateComplete, isDIDCommV2)](#module_didcomm--exports.DIDComm.connectToMediator)
+        * _inner_
+            * [~getPresentationAttachmentAndThreadID(presentationRequest)](#module_didcomm--exports.DIDComm..getPresentationAttachmentAndThreadID)
 
 <a name="exp_module_didcomm--exports.DIDComm"></a>
 
@@ -831,6 +949,7 @@ Get DID Invitation from edge router.
 | Param | Description |
 | --- | --- |
 | endpoint | edge router endpoint |
+| isDIDCommV2 | flag using DIDComm V2 |
 
 <a name="module_didcomm--exports.DIDComm.getMediatorConnections"></a>
 
@@ -845,7 +964,7 @@ Get router/mediator connections from agent.
 
 <a name="module_didcomm--exports.DIDComm.connectToMediator"></a>
 
-#### exports.DIDComm.connectToMediator(agent, endpoint, wait)
+#### exports.DIDComm.connectToMediator(agent, endpoint, waitForStateComplete, isDIDCommV2)
 Connect given agent to edge mediator/router.
 
 **Kind**: static method of [<code>exports.DIDComm</code>](#exp_module_didcomm--exports.DIDComm)  
@@ -854,7 +973,19 @@ Connect given agent to edge mediator/router.
 | --- | --- |
 | agent | trustbloc agent |
 | endpoint | edge router endpoint |
-| wait | for did exchange state complete message |
+| waitForStateComplete | wait for did exchange state complete message |
+| isDIDCommV2 | flag using DIDComm V2 |
+
+<a name="module_didcomm--exports.DIDComm..getPresentationAttachmentAndThreadID"></a>
+
+#### exports.DIDComm~getPresentationAttachmentAndThreadID(presentationRequest)
+Get attachment and threadID from presentationRequest instance based on DIDComm V1 or V2 formats.
+
+**Kind**: inner method of [<code>exports.DIDComm</code>](#exp_module_didcomm--exports.DIDComm)  
+
+| Param | Description |
+| --- | --- |
+| presentationRequest | instance |
 
 <a name="module_vcwallet"></a>
 
@@ -883,6 +1014,7 @@ vcwallet module provides verifiable credential wallet SDK for aries universal wa
             * [.presentProof(auth, threadID, presentation, options)](#module_vcwallet--exports.UniversalWallet.UniversalWallet+presentProof) ⇒ <code>Promise.&lt;Object&gt;</code>
             * [.proposeCredential(auth, invitation, connectOptions, proposeOptions)](#module_vcwallet--exports.UniversalWallet.UniversalWallet+proposeCredential) ⇒ <code>Promise.&lt;Object&gt;</code>
             * [.requestCredential(auth, threadID, presentation, options)](#module_vcwallet--exports.UniversalWallet.UniversalWallet+requestCredential) ⇒ <code>Promise.&lt;Object&gt;</code>
+            * [.resolveCredential(auth, manifest, options)](#module_vcwallet--exports.UniversalWallet.UniversalWallet+resolveCredential) ⇒ <code>Promise.&lt;Object&gt;</code>
         * _static_
             * [.contentTypes](#module_vcwallet--exports.UniversalWallet.contentTypes) : <code>enum</code>
             * [.createWalletProfile(agent, userID, profileOptions)](#module_vcwallet--exports.UniversalWallet.createWalletProfile) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -1212,6 +1344,26 @@ sends request credential message from wallet to issuer as part of ongoing creden
 | options.waitForDone | <code>Bool</code> | (optional) If true then wallet will wait for credential fulfillment message or problem report . |
 | options.WaitForDoneTimeout | <code>Time</code> | (optional) timeout to wait for credential fulfillment or problem report. |
 
+<a name="module_vcwallet--exports.UniversalWallet.UniversalWallet+resolveCredential"></a>
+
+#### exports.UniversalWallet.resolveCredential(auth, manifest, options) ⇒ <code>Promise.&lt;Object&gt;</code>
+resolves given credential manifest by credential fulfillment or credential.
+Supports: https://identity.foundation/credential-manifest/
+
+**Kind**: instance method of [<code>exports.UniversalWallet</code>](#exp_module_vcwallet--exports.UniversalWallet)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - - promise of object containing request credential status & redirect info or error if operation fails.  
+**See**: [Credential Manifest ](https://identity.foundation/credential-manifest)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| auth | <code>String</code> | authorization token for performing this wallet operation. |
+| manifest | <code>Object</code> | credential manifest to be used for resolving credential. |
+| options | <code>Object</code> | credential or fulfillment to resolve. |
+| options.fulfillment | <code>String</code> | (optional) credential fulfillment to be resolved.  if provided, then this option takes precedence over credential resolve option. |
+| options.credential | <code>Object</code> | (optional) raw credential to be resolved (accepting 'ldp_vc' format only).  This option has to be provided with descriptor ID. |
+| options.credentialID | <code>String</code> | (optional) ID of the credential to be resolved which is persisted in wallet content store.  This option has to be provided with descriptor ID. |
+| options.descriptorID | <code>String</code> | (optional) output descriptor ID of the descriptor from manifest to be used for resolving given  credential or credentialID. This option is required only when a raw credential or credential ID is to be resolved. |
+
 <a name="module_vcwallet--exports.UniversalWallet.contentTypes"></a>
 
 #### exports.UniversalWallet.contentTypes : <code>enum</code>
@@ -1414,6 +1566,7 @@ Saves TrustBloc wallet user preferences.
 | preferences.controller | <code>String</code> | (optional) default controller to be used for digital proof for this wallet user. |
 | preferences.verificationMethod | <code>Object</code> | (optional) default verificationMethod to be used for digital proof for this wallet user. |
 | preferences.proofType | <code>String</code> | (optional) default proofType to be used for digital proof for this wallet user. |
+| preferences.skipWelcomeMsg | <code>Boolean</code> | (optional) represents whether this wallet user has dismissed a welcome message in the UI. |
 
 <a name="module_wallet-user--exports.WalletUser.WalletUser+updatePreferences"></a>
 
@@ -1433,6 +1586,7 @@ Updates TrustBloc wallet user preferences.
 | preferences.controller | <code>String</code> | (optional) default controller to be used for digital proof for this wallet user. |
 | preferences.verificationMethod | <code>Object</code> | (optional) default verificationMethod to be used for digital proof for this wallet user. |
 | preferences.proofType | <code>String</code> | (optional) default proofType to be used for digital proof for this wallet user. |
+| preferences.skipWelcomeMsg | <code>Boolean</code> | (optional) represents whether this wallet user has dismissed a welcome message in the UI. |
 
 <a name="module_wallet-user--exports.WalletUser.WalletUser+getPreferences"></a>
 
@@ -1515,6 +1669,15 @@ Updates given presentation submission presentation by removing duplicate descrip
 ## findAttachmentByFormat
 Finds attachment by given format.
  Supporting Attachment Format from DIDComm V1.
+
+ Note: Currently finding only one attachment per format.
+
+**Kind**: global constant  
+<a name="findAttachmentByFormatV2"></a>
+
+## findAttachmentByFormatV2
+Finds attachment by given format.
+ Supporting Attachment Format from DIDComm V2.
 
  Note: Currently finding only one attachment per format.
 

--- a/cmd/wallet-js-sdk/src/did/didmanager.js
+++ b/cmd/wallet-js-sdk/src/did/didmanager.js
@@ -66,12 +66,13 @@ export class DIDManager {
       collection,
     } = {}
   ) {
-    const [keySet, recoveryKeySet, updateKeySet, keyAgreementKeySet] = await Promise.all([
-      this.wallet.createKeyPair(auth, { keyType }),
-      this.wallet.createKeyPair(auth, { keyType: DEFAULT_KEY_TYPE }),
-      this.wallet.createKeyPair(auth, { keyType: DEFAULT_KEY_TYPE }),
-      this.wallet.createKeyPair(auth, { keyType: keyAgreementKeyType }),
-    ]);
+    const [keySet, recoveryKeySet, updateKeySet, keyAgreementKeySet] =
+      await Promise.all([
+        this.wallet.createKeyPair(auth, { keyType }),
+        this.wallet.createKeyPair(auth, { keyType: DEFAULT_KEY_TYPE }),
+        this.wallet.createKeyPair(auth, { keyType: DEFAULT_KEY_TYPE }),
+        this.wallet.createKeyPair(auth, { keyType: keyAgreementKeyType }),
+      ]);
 
     const createDIDRequest = {
       // TODO make below as function args

--- a/cmd/wallet-js-sdk/src/universal/vc-wallet.js
+++ b/cmd/wallet-js-sdk/src/universal/vc-wallet.js
@@ -517,6 +517,45 @@ export class UniversalWallet {
       WaitForDoneTimeout,
     });
   }
+
+  /**
+   *  resolves given credential manifest by credential fulfillment or credential.
+   * Supports: https://identity.foundation/credential-manifest/
+   *
+   *  @see {@link https://identity.foundation/credential-manifest|Credential Manifest }
+   *
+   *  @param {String} auth -  authorization token for performing this wallet operation.
+   *  @param {Object} manifest - credential manifest to be used for resolving credential.
+   *
+   *  @param {Object} options - credential or fulfillment to resolve.
+   *
+   *  @param {String} options.fulfillment - (optional) credential fulfillment to be resolved.
+   *  if provided, then this option takes precedence over credential resolve option.
+   *
+   *  @param {Object} options.credential - (optional) raw credential to be resolved (accepting 'ldp_vc' format only).
+   *  This option has to be provided with descriptor ID.
+   *  @param {String} options.credentialID - (optional) ID of the credential to be resolved which is persisted in wallet content store.
+   *  This option has to be provided with descriptor ID.
+   *  @param {String} options.descriptorID - (optional) output descriptor ID of the descriptor from manifest to be used for resolving given
+   *  credential or credentialID. This option is required only when a raw credential or credential ID is to be resolved.
+   *
+   * @returns {Promise<Object>} - promise of object containing request credential status & redirect info or error if operation fails.
+   */
+  async resolveCredential(
+    auth,
+    manifest,
+    { fulfillment, credential, credentialID = "", descriptorID = "" } = {}
+  ) {
+    return await this.agent.vcwallet.resolveCredentialManifest({
+      userID: this.user,
+      auth,
+      manifest,
+      fulfillment,
+      credential,
+      credentialID,
+      descriptorID,
+    });
+  }
 }
 
 /**

--- a/cmd/wallet-js-sdk/src/user/wallet-user.js
+++ b/cmd/wallet-js-sdk/src/user/wallet-user.js
@@ -177,8 +177,8 @@ export class WalletUser {
    *  @param {String} preferences.controller - (optional) default controller to be used for digital proof for this wallet user.
    *  @param {Object} preferences.verificationMethod - (optional) default verificationMethod to be used for digital proof for this wallet user.
    *  @param {String} preferences.proofType - (optional) default proofType to be used for digital proof for this wallet user.
-   *  @param {Boolean} preferences.skipWelcomeMsg - (optional) represents whether this wallet user has dismissed a welcome message in the UI. 
-   * 
+   *  @param {Boolean} preferences.skipWelcomeMsg - (optional) represents whether this wallet user has dismissed a welcome message in the UI.
+   *
    *  @returns {Promise<Object>} - empty promise or error if operation fails.
    */
   async savePreferences(
@@ -203,7 +203,7 @@ export class WalletUser {
       controller,
       verificationMethod,
       proofType,
-      skipWelcomeMsg
+      skipWelcomeMsg,
     });
   }
 
@@ -224,7 +224,15 @@ export class WalletUser {
    */
   async updatePreferences(
     auth,
-    { name, description, image, controller, verificationMethod, proofType, skipWelcomeMsg }
+    {
+      name,
+      description,
+      image,
+      controller,
+      verificationMethod,
+      proofType,
+      skipWelcomeMsg,
+    }
   ) {
     let { content } = await this.getPreferences(auth);
     if (!content) {
@@ -244,7 +252,7 @@ export class WalletUser {
       controller,
       verificationMethod,
       proofType,
-      skipWelcomeMsg
+      skipWelcomeMsg,
     });
 
     Object.keys(updates).forEach((key) => (content[key] = updates[key]));

--- a/cmd/wallet-js-sdk/src/util/helper.js
+++ b/cmd/wallet-js-sdk/src/util/helper.js
@@ -198,6 +198,22 @@ export const findAttachmentByFormat = (formats, attachments, format) => {
 };
 
 /**
+ *  Finds attachment by given format.
+ *  Supporting Attachment Format from DIDComm V2.
+ *
+ *  Note: Currently finding only one attachment per format.
+ */
+export const findAttachmentByFormatV2 = (attachments, format) => {
+  const attachmentsFound = jp.query(attachments, `$[?(@.format=="${format}")]`);
+
+  if (attachmentsFound.length == 1) {
+    return attachmentsFound[0].data.json;
+  }
+
+  return;
+};
+
+/**
  *  Reads out-of-band invitation goal code.
  *  Supports DIDComm V1 & V2
  */

--- a/cmd/wallet-js-sdk/test/fixtures/testdata/allvcs-cred-manifest.json
+++ b/cmd/wallet-js-sdk/test/fixtures/testdata/allvcs-cred-manifest.json
@@ -1,0 +1,146 @@
+{
+  "id": "xee75a16-19f5-4273-84ce-5da69ee2b9gf",
+  "version": "0.1.0",
+  "issuer": {
+    "id": "did:example:123?linked-domains=3",
+    "name": "Example Authority",
+    "styles": {}
+  },
+  "output_descriptors": [
+    {
+      "id": "udc_output",
+      "schema": "https://www.w3.org/2018/credentials/examples/v1",
+      "display": {
+        "title": {
+          "path": [
+            "$.title",
+            "$.vc.title"
+          ],
+          "schema": {
+            "type": "string"
+          },
+          "fallback": "Bachelor's Degree"
+        },
+        "subtitle": {
+          "path": [
+            "$.minor",
+            "$.vc.minor"
+          ],
+          "schema": {
+            "type": "string"
+          },
+          "fallback": ""
+        },
+        "description": {
+          "text": "Awarded for completing a four year program at Example University."
+        },
+        "properties": [
+          {
+            "path": [
+              "$.name",
+              "$.credentialSubject.name"
+            ],
+            "schema": {
+              "type": "string"
+            },
+            "fallback": "Not Applicable",
+            "label": "Degree Holder's name"
+          },
+          {
+            "path": [
+              "$.credentialSubject.degree.type"
+            ],
+            "schema": {
+              "type": "string"
+            },
+            "fallback": "Unknown",
+            "label": "Degree"
+          }
+        ]
+      },
+      "styles": {
+        "thumbnail": {
+          "uri": "http://example-university.org/logo.png",
+          "alt": "Example University logo"
+        },
+        "hero": {
+          "uri": "http://example-university.org/hero.png",
+          "alt": "Example University students in graduation ceremony"
+        },
+        "background": {
+          "color": "#ff0000"
+        },
+        "text": {
+          "color": "#d4d400"
+        }
+      }
+    },
+    {
+      "id": "prc_output",
+      "schema": "https://w3id.org/citizenship/v1",
+      "display": {
+        "title": {
+          "path": [
+            "$.name",
+            "$.vc.name"
+          ],
+          "schema": {
+            "type": "string"
+          },
+          "fallback": "Permanent Resident Card"
+        },
+        "subtitle": {
+          "path": [
+            "$.description",
+            "$.vc.description"
+          ],
+          "schema": {
+            "type": "string"
+          },
+          "fallback": ""
+        },
+        "description": {
+          "text": "PR card of John Smith."
+        },
+        "properties": [
+          {
+            "path": [
+              "$.credentialSubject.givenName"
+            ],
+            "schema": {
+              "type": "string"
+            },
+            "fallback": "Not Applicable",
+            "label": "Card Holder's first name"
+          },
+          {
+            "path": [
+              "$.credentialSubject.familyName"
+            ],
+            "schema": {
+              "type": "string"
+            },
+            "fallback": "Unknown",
+            "label": "Card Holder's family name"
+          }
+        ]
+      },
+      "styles": {
+        "thumbnail": {
+          "uri": "http://example-university.org/logo.png",
+          "alt": "Example University logo"
+        },
+        "hero": {
+          "uri": "http://example-university.org/hero.png",
+          "alt": "Example University students in graduation ceremony"
+        },
+        "background": {
+          "color": "#ff0000"
+        },
+        "text": {
+          "color": "#d4d400"
+        }
+      }
+    }
+  ]
+}

--- a/cmd/wallet-js-sdk/test/fixtures/testdata/cred-fulfillment-udc-vp.json
+++ b/cmd/wallet-js-sdk/test/fixtures/testdata/cred-fulfillment-udc-vp.json
@@ -5,7 +5,7 @@
       "format": "ldp_vc",
       "id": "udc_output",
       "path": "$.verifiableCredential[0]"
-    }], "id": "a30e3b91-fb77-4d22-95fa-871689c322e2", "manifest_id": "dcc75a16-19f5-4273-84ce-4da69ee2b7fe"
+    }], "id": "a30e3b91-fb77-4d22-95fa-871689c322e2", "manifest_id": "mdd75a16-19f5-4273-84ce-5da69ee2b9gf"
   },
   "proof": {
     "created": "2022-01-14T13:53:49.219598-05:00",

--- a/cmd/wallet-js-sdk/test/fixtures/testdata/cred-manifest-withoptions.json
+++ b/cmd/wallet-js-sdk/test/fixtures/testdata/cred-manifest-withoptions.json
@@ -76,9 +76,5 @@
       }
     }
   ],
-  "format": {},
-  "options":{
-    "challenge":"508adef4-b8e0-4edf-a53d-a260371c1423",
-    "domain":"9rf25a28rs96"
-  }
+  "format": {}
 }

--- a/cmd/wallet-js-sdk/test/fixtures/testdata/prc-cred-manifest.json
+++ b/cmd/wallet-js-sdk/test/fixtures/testdata/prc-cred-manifest.json
@@ -1,0 +1,78 @@
+{
+  "id": "prc75a16-19f5-4273-84ce-0da69ee2b3rt",
+  "version": "0.1.0",
+  "issuer": {
+    "id": "did:example:123?linked-domains=3",
+    "name": "Example Authority",
+    "styles": {}
+  },
+  "output_descriptors": [
+    {
+      "id": "prc_output",
+      "schema": "https://w3id.org/citizenship/v1",
+      "display": {
+        "title": {
+          "path": [
+            "$.name",
+            "$.vc.name"
+          ],
+          "schema": {
+            "type": "string"
+          },
+          "fallback": "Permanent Resident Card"
+        },
+        "subtitle": {
+          "path": [
+            "$.description",
+            "$.vc.description"
+          ],
+          "schema": {
+            "type": "string"
+          },
+          "fallback": ""
+        },
+        "description": {
+          "text": "PR card of John Smith."
+        },
+        "properties": [
+          {
+            "path": [
+              "$.credentialSubject.givenName"
+            ],
+            "schema": {
+              "type": "string"
+            },
+            "fallback": "Not Applicable",
+            "label": "Card Holder's first name"
+          },
+          {
+            "path": [
+              "$.credentialSubject.familyName"
+            ],
+            "schema": {
+              "type": "string"
+            },
+            "fallback": "Unknown",
+            "label": "Card Holder's family name"
+          }
+        ]
+      },
+      "styles": {
+        "thumbnail": {
+          "uri": "http://example-university.org/logo.png",
+          "alt": "Example University logo"
+        },
+        "hero": {
+          "uri": "http://example-university.org/hero.png",
+          "alt": "Example University students in graduation ceremony"
+        },
+        "background": {
+          "color": "#ff0000"
+        },
+        "text": {
+          "color": "#d4d400"
+        }
+      }
+    }
+  ]
+}

--- a/cmd/wallet-js-sdk/test/fixtures/testdata/udc-cred-manifest.json
+++ b/cmd/wallet-js-sdk/test/fixtures/testdata/udc-cred-manifest.json
@@ -1,0 +1,79 @@
+{
+  "id": "mdd75a16-19f5-4273-84ce-5da69ee2b9gf",
+  "version": "0.1.0",
+  "issuer": {
+    "id": "did:example:123?linked-domains=3",
+    "name": "Example Authority",
+    "styles": {}
+  },
+  "output_descriptors": [
+    {
+      "id": "udc_output",
+      "schema": "https://www.w3.org/2018/credentials/examples/v1",
+      "display": {
+        "title": {
+          "path": [
+            "$.title",
+            "$.vc.title"
+          ],
+          "schema": {
+            "type": "string"
+          },
+          "fallback": "Bachelor's Degree"
+        },
+        "subtitle": {
+          "path": [
+            "$.minor",
+            "$.vc.minor"
+          ],
+          "schema": {
+            "type": "string"
+          },
+          "fallback": ""
+        },
+        "description": {
+          "text": "Awarded for completing a four year program at Example University."
+        },
+        "properties": [
+          {
+            "path": [
+              "$.name",
+              "$.credentialSubject.name"
+            ],
+            "schema": {
+              "type": "string"
+            },
+            "fallback": "Not Applicable",
+            "label": "Degree Holder's name"
+          },
+          {
+            "path": [
+              "$.credentialSubject.degree.type"
+            ],
+            "schema": {
+              "type": "string"
+            },
+            "fallback": "Unknown",
+            "label": "Degree"
+          }
+        ]
+      },
+      "styles": {
+        "thumbnail": {
+          "uri": "http://example-university.org/logo.png",
+          "alt": "Example University logo"
+        },
+        "hero": {
+          "uri": "http://example-university.org/hero.png",
+          "alt": "Example University students in graduation ceremony"
+        },
+        "background": {
+          "color": "#ff0000"
+        },
+        "text": {
+          "color": "#d4d400"
+        }
+      }
+    }
+  ]
+}

--- a/cmd/wallet-js-sdk/test/fixtures/testdata/udc-vc.json
+++ b/cmd/wallet-js-sdk/test/fixtures/testdata/udc-vc.json
@@ -13,6 +13,9 @@
     "name": "Jayden Doe",
     "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
   },
+
+  "name": "University Degree",
+  "description": "University Degree of Mr.John Smith",
   "expirationDate": "2020-01-01T19:23:24Z",
   "id": "http://example.edu/credentials/11873",
   "issuanceDate": "2010-01-01T19:23:24Z",

--- a/cmd/wallet-js-sdk/test/specs/common.js
+++ b/cmd/wallet-js-sdk/test/specs/common.js
@@ -16,6 +16,9 @@ export const PRESENT_PROOF_ACTION_TOPIC = "present-proof_actions"
 export const ISSUE_CREDENTIAL_STATE_TOPIC = "issue-credential_states"
 export const ISSUE_CREDENTIAL_ACTION_TOPIC = "issue-credential_actions"
 export const MSG_TYPE_OFFER_CREDENTIAL_V2 = "https://didcomm.org/issue-credential/2.0/offer-credential"
+export const MSG_TYPE_OFFER_CREDENTIAL_V3 = "https://didcomm.org/issue-credential/3.0/offer-credential"
+export const MSG_TYPE_PROPOSE_CREDENTIAL_V2 = "https://didcomm.org/issue-credential/2.0/propose-credential"
+export const MSG_TYPE_PROPOSE_CREDENTIAL_V3 = "https://didcomm.org/issue-credential/3.0/propose-credential"
 export const ATTACH_FORMAT_CREDENTIAL_MANIFEST = "dif/credential-manifest/manifest@v1.0"
 export const ATTACH_FORMAT_CREDENTIAL_FULFILLMENT = "dif/credential-manifest/fulfillment@v1.0"
 export const ATTACH_FORMAT_ISSUE_CREDENTIAL = "aries/ld-proof-vc@v1.0"
@@ -73,5 +76,13 @@ export const retryWithDelay = async (
         await wait(interval)
         return retryWithDelay(fn, (retries - 1), interval, finalErr);
     }
+}
+
+// read manifest and replace manifest ID so that same file can be reused for many tests.
+export const prepareTestManifest = (file) => {
+    const manifest = getJSONTestData(file)
+    manifest.id = uuid()
+
+    return manifest
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,12 @@ go 1.17
 require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59
+	github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.1.4-0.20220114172935-0e96d787f80f
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20211217171603-637696af6620
-	github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220126164804-6041c17d6e59
-	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59
+	github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220202170435-bb5bedb39f36
+	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36
 	github.com/igor-pavlenko/httpsignatures-go v0.0.23
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.8-0.20211216164925-ce0474dc589d

--- a/go.sum
+++ b/go.sum
@@ -746,8 +746,8 @@ github.com/hyperledger/aries-framework-go v0.1.8-0.20211201185059-733a3370f501/g
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211216162950-a0879ff5e52a/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211217135421-f68d5698237a/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
-github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59 h1:nKA64Ex2UuHvN3n+bYTki5pAkqSRYxfPU2PaWu3D60A=
-github.com/hyperledger/aries-framework-go v0.1.8-0.20220126164804-6041c17d6e59/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
+github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36 h1:LhpKD6oZCKwTdG2PLwv2BSYbAEv+8CNyISF0EWOyhm8=
+github.com/hyperledger/aries-framework-go v0.1.8-0.20220202170435-bb5bedb39f36/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:FtlFhPHMyLORgrPpvWSmEQSNhLiwAQ4V6rqNPfuDj0o=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:aiO9mXZBykIEwmgp9sSdpMuTw0P7b+ZFUltcIB9ZccY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc h1:VI3JX0ymIkI5amU2sKP+25EuopLjkDvUHfmJ/jsPFK0=
@@ -760,8 +760,8 @@ github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-2021
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:7D+Y5J9cIsUrMGFAsIED+3bAPNjxp6ggXo0/kT5N6BI=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:00tdiDIlEdmcLuN/5zSr3NI8AycnvRMMt4M07VSqiqw=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210820175050-dcc7a225178d/go.mod h1:i40JkMHCh9cHHxSc1SYznO3xDH6ly5CE0B3vPYZVeWI=
-github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220126164804-6041c17d6e59 h1:ve9K4QK1365Lv/kDiZTtkLgdX1baG7oHrc4bC0CXBDU=
-github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220126164804-6041c17d6e59/go.mod h1:57n+xmBP9rDI3ZhgreKCi+4dZpPRl8QgHK29kR3cdPM=
+github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220202170435-bb5bedb39f36 h1:hVPtkaSfbC6DYOk9zec9nlM3W9rzQis8gzTVXcjHv0w=
+github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:57n+xmBP9rDI3ZhgreKCi+4dZpPRl8QgHK29kR3cdPM=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210320144851-40976de98ccf/go.mod h1:HVV8sifdHIyLkrlgmK/6+3YWKnOJPUfoNU+4SwQqMSs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:kJT7bcaKsvk1lMp2jqS8srF+ZUie2H4MoPbL2V29dgA=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:uGc7F3tXQIY6xjs8VEI6/oxp4ZDXDfGjPMCTgax5Zhc=
@@ -771,8 +771,8 @@ github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-202106032
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:k8CjDLBLxygTEj3D077OeH4SJsVE3mK60AyeO/C9sxs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210820175050-dcc7a225178d/go.mod h1:wdgGPwXzih+QD2Q4nvMnGO0dm0D0rxmzQcSNLcW6fcg=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210910143505-343c246c837c/go.mod h1:bFeSTLeQktv7TrPVaxeKE7H6E3dVBAG29ezdDS1Eyu0=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59 h1:3CJUAVUj3FxQvWN55ZFnv7XzXqyYgI3O+vIyg3J4DoY=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220126164804-6041c17d6e59/go.mod h1:yLgRpVlZ2heeeOpTgvEnG/yHL9q1keUu5ILQ6s2qpLU=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36 h1:vtnI3aDZbg6jN443TROvzhaZhUFMGwFoyE8lCF6VN6Q=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:yLgRpVlZ2heeeOpTgvEnG/yHL9q1keUu5ILQ6s2qpLU=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210310001230-bc1bd8ea889c/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210310160016-d5eea2ecdd50/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
@@ -794,8 +794,8 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20210902194940-97c6f2cded6c
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210909135806-a1c268dfb633/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20211203210130-e927c9ed581a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20211206182816-9cdcbcd09dc2/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59 h1:cYgM+V8mJi5sZi+fbL8/77MLf8jGXtpgNza4t3gyVbs=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220126164804-6041c17d6e59/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36 h1:FrvS7pxk4dRQi+IvKlmavcDHJccclQWvryoQb3OhLnk=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220202170435-bb5bedb39f36/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210310160016-d5eea2ecdd50/go.mod h1:AybsT4/saiuxdVhK5CgOLIkcNMPZtX3GAUMOjHcLLjk=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:JHzDtgJLd0134iLFXLxGBjJF+Z+TgiElA/5oVgMazts=


### PR DESCRIPTION
- introduced credential metadata data model which gets created based on
metadata of the credential being saved.
- this can be used later on to dispaly credential specific metadata in
UI without fetching actual credential to browser
- credential metadata can be used for features like rename credential

- introduced credential manifest data model which will be required data
model to save credentials in wallet and it can be used later on display
credential info in user interfaces
- added interfaces like getting credential metaadata, getting all
credential metadata, resolving credential etc

- Closes https://github.com/trustbloc/wallet/issues/1421
- Closes https://github.com/trustbloc/wallet/issues/1422
- Closes #321

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>