### PR TITLE
feat: added content-digest header & generation logic for gnap requests

### DIFF
--- a/cmd/wallet-js-sdk/package-lock.json
+++ b/cmd/wallet-js-sdk/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
+        "js-base64": "^3.7.2",
         "jsonpath": "^1.1.1",
         "uuid": "^8.3.2"
       },
@@ -3049,6 +3050,11 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -8538,6 +8544,11 @@
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       }
+    },
+    "js-base64": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",

--- a/cmd/wallet-js-sdk/package.json
+++ b/cmd/wallet-js-sdk/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
+    "js-base64": "^3.7.2",
     "jsonpath": "^1.1.1",
     "uuid": "^8.3.2"
   }

--- a/cmd/wallet-js-sdk/src/digest/digest.js
+++ b/cmd/wallet-js-sdk/src/digest/digest.js
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { fromUint8Array } from "js-base64";
+
+/**
+ * Generates and returns a hash for the data object provided using the specified encryption algorithm.
+ *
+ *  @param {String} name - name of the encryption algorithm to be used for generating the digest.
+ *  @param {Object} data - data object to generate the digest for.
+ *
+ * @returns {String} - generated hash for the data provided
+ */
+export default async function getDigest(name, data) {
+  switch (name) {
+    case "SHA-256": {
+      const encoder = new TextEncoder();
+      // hash the data
+      const hashBuffer = await window.crypto.subtle.digest(
+        name,
+        encoder.encode(data) // encode as (utf-8) Uint8Array
+      );
+      // convert buffer to byte array
+      const hashArray = new Uint8Array(hashBuffer);
+      // Encode byte array with base64
+      const encodedHash = fromUint8Array(hashArray, true);
+      return `sha-256=:${encodedHash}:`;
+    }
+    case "SHA-512": {
+      const encoder = new TextEncoder();
+      // hash the data
+      const hashBuffer = await window.crypto.subtle.digest(
+        name,
+        encoder.encode(data) // encode as (utf-8) Uint8Array
+      );
+      // convert buffer to byte array
+      const hashArray = new Uint8Array(hashBuffer);
+      // Encode byte array with base64
+      const encodedHash = fromUint8Array(hashArray, true);
+      return `sha-512=:${encodedHash}:`;
+    }
+    default:
+      throw new Error("unsupported digest encryption algorithm provided");
+  }
+}

--- a/cmd/wallet-js-sdk/src/gnap/client.js
+++ b/cmd/wallet-js-sdk/src/gnap/client.js
@@ -6,7 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 import axios from "axios";
 // TODO : Implement http message signature module in JS (https://github.com/trustbloc/agent-sdk/issues/348)
-// import { encode } from "js-base64";
+// import { encodeURI } from "js-base64";
+import getDigest from "../digest/digest";
 
 const GNAP_BASE_PATH = "/gnap";
 const AUTH_REQUEST_PATH = GNAP_BASE_PATH + "/auth";
@@ -44,6 +45,7 @@ export class Client {
     const gnapResp = await axios.post(url, req, {
       headers: {
         "Content-Type": CONTENT_TYPE,
+        "content-digest": getDigest("SHA-256", req),
         // "Signature-Input": "TODO", // TODO update signature input
         // TODO : Implement http message signature module in JS (https://github.com/trustbloc/agent-sdk/issues/348)
         // Signature: encode(sig, true),
@@ -57,20 +59,18 @@ export class Client {
   async continue(req, continue_token) {
     // TODO : Implement http message signature module in JS (https://github.com/trustbloc/agent-sdk/issues/348)
     // const sig = this.signer.Sign(req);
+    const url = this.gnapAuthServerURL + AUTH_CONTINUE_PATH;
 
-    const gnapResp = await axios.post(
-      this.gnapAuthServerURL + AUTH_CONTINUE_PATH,
-      req,
-      {
-        headers: {
-          "Content-Type": CONTENT_TYPE,
-          "Authorization": "GNAP " + continue_token,
-          // "Signature-Input": "TODO", // TODO update signature input
-          // TODO : Implement http message signature module in JS (https://github.com/trustbloc/agent-sdk/issues/348)
-          // Signature: encode(sig, true),
-        },
-      }
-    );
+    const gnapResp = await axios.post(url, req, {
+      headers: {
+        "Content-Type": CONTENT_TYPE,
+        Authorization: "GNAP " + continue_token,
+        "Content-Digest": getDigest("SHA-256", req),
+        // "Signature-Input": "TODO", // TODO update signature input
+        // TODO : Implement http message signature module in JS (https://github.com/trustbloc/agent-sdk/issues/348)
+        // Signature: encode(sig, true),
+      },
+    });
 
     return gnapResp;
   }

--- a/cmd/wallet-js-sdk/test/specs/digest/digest.spec.js
+++ b/cmd/wallet-js-sdk/test/specs/digest/digest.spec.js
@@ -1,0 +1,108 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { expect } from "chai";
+import getDigest from "../../../src/digest/digest";
+
+const kty = "EC";
+const kid = "key1";
+const crv = "P-256";
+const alg = "ES256";
+const x = "TDiE9hqocEOewpSgI5r_yhoOy1EuetUpWcKvlrC9Ix4";
+const y = "pC76IX_6YRQ5CaxmcmcixTA-dWjHpuKoYICir7VYQ_A";
+
+const expectThrowsAsync = async (method, errorMessage) => {
+  let error = null;
+  try {
+    await method();
+  } catch (err) {
+    error = err;
+  }
+  expect(error).to.be.an("Error");
+  if (errorMessage) {
+    expect(error.message).to.equal(errorMessage);
+  }
+};
+
+describe("HTTP Signature Module - Generating Digest", function () {
+  const mockData = {
+    access_token: [
+      {
+        access: [
+          {
+            type: "trustbloc.dev/types/gnap/userdata-access",
+            actions: ["read", "write", "update", "delete"],
+            locations: ["edv.provider.com/api"],
+            "subject-keys": ["sub"],
+          },
+          {
+            type: "trustbloc.dev/types/gnap/kms-access",
+            actions: ["sign", "verify", "encrypt", "decrypt"],
+            locations: ["kms.provider.com/api/user"],
+            "subject-keys": ["sub"],
+          },
+        ],
+        label: "access-1",
+      },
+      {
+        access: [
+          {
+            type: "trustbloc.dev/types/gnap/legacy-api",
+            actions: ["read", "append"],
+            locations: ["log.legacy.com/user"],
+          },
+        ],
+        label: "log-access",
+        flags: ["bearer"],
+      },
+    ],
+    client: {
+      key: {
+        proof: "httpsig",
+        jwk: {
+          kty,
+          kid,
+          crv,
+          alg,
+          x,
+          y,
+        },
+      },
+    },
+    interact: {
+      start: ["redirect"],
+      finish: {
+        method: "redirect",
+        uri: "https://wallet.app/login/callback",
+        nonce: "foo-bar-baz",
+      },
+    },
+  };
+
+  it("successfully generates a hash using a SHA-256 encryption algorithm name for the provided data", async () => {
+    const mockValidAlgorithmName = "SHA-256";
+    const hash = await getDigest(mockValidAlgorithmName, mockData);
+    expect(hash).to.equal(
+      `sha-256=:soyUshlcjtJZ8LQVqu4_ObCykgpFN2EUmfoESVaReiE:`
+    );
+  });
+
+  it("successfully generates a hash using a SHA-512 encryption algorithm name for the provided data", async () => {
+    const mockValidAlgorithmName = "SHA-512";
+    const hash = await getDigest(mockValidAlgorithmName, mockData);
+    expect(hash).to.equal(
+      `sha-512=:HcytP60FiinM744AP6cbur9YdDGsWlX7NiaL95WMXzyzERasnoVexhu5ty7L1IT3BL7gMnB_sOrSStK-6XuaOQ:`
+    );
+  });
+
+  it("throws an error for unsupported encryption algorithm provided", async () => {
+    const mockInvalidAlgorithmName = "SHA-1";
+    await expectThrowsAsync(
+      () => getDigest(mockInvalidAlgorithmName, mockData),
+      "unsupported digest encryption algorithm provided"
+    );
+  });
+});


### PR DESCRIPTION
Fixes #368

Added `content-digest` headers to GNAP requests and corresponding logic as per the [specs](https://www.ietf.org/archive/id/draft-ietf-gnap-core-protocol-09.html#section-7.3.1-2).

Signed-off-by: Anton Biriukov <anton.biriukov@securekey.com>