### PR TITLE
test: implemented unit tests for http sig module

### DIFF
--- a/cmd/wallet-js-sdk/package-lock.json
+++ b/cmd/wallet-js-sdk/package-lock.json
@@ -30,6 +30,7 @@
         "karma-spec-reporter": "^0.0.34",
         "karma-webpack": "^5.0.0",
         "mocha": "^10.0.0",
+        "mockdate": "^3.0.5",
         "moxios": "^0.4.0",
         "prettier": "^2.6.2",
         "terser-webpack-plugin": "^5.3.3",
@@ -3826,6 +3827,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
       "dev": true
     },
     "node_modules/moxios": {
@@ -9170,6 +9177,12 @@
           "dev": true
         }
       }
+    },
+    "mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "dev": true
     },
     "moxios": {
       "version": "0.4.0",

--- a/cmd/wallet-js-sdk/package.json
+++ b/cmd/wallet-js-sdk/package.json
@@ -52,6 +52,7 @@
     "karma-spec-reporter": "^0.0.34",
     "karma-webpack": "^5.0.0",
     "mocha": "^10.0.0",
+    "mockdate": "^3.0.5",
     "moxios": "^0.4.0",
     "prettier": "^2.6.2",
     "terser-webpack-plugin": "^5.3.3",

--- a/cmd/wallet-js-sdk/src/httpsig/signer.js
+++ b/cmd/wallet-js-sdk/src/httpsig/signer.js
@@ -23,19 +23,19 @@ import { fromUint8Array } from "js-base64";
 export class HTTPSigner {
   constructor({ authorization = "", signingKey }) {
     if (!signingKey) {
-      throw new Error(
+      throw new TypeError(
         "Error initializing HTTPSigner: signingKey cannot be empty"
       );
     } else if (!signingKey.publicKey) {
-      throw new Error(
+      throw new TypeError(
         "Error initializing HTTPSigner: publicKey cannot be empty"
       );
     } else if (!signingKey.privateKey) {
-      throw new Error(
+      throw new TypeError(
         "Error initializing HTTPSigner: privateKey cannot be empty"
       );
     } else if (!signingKey.kid) {
-      throw new Error("Error initializing HTTPSigner: kid cannot be empty");
+      throw new TypeError("Error initializing HTTPSigner: kid cannot be empty");
     }
     this.authorization = authorization;
     this.signingKey = signingKey;
@@ -47,16 +47,11 @@ export class HTTPSigner {
    * @returns {String} - generated signature params
    */
   generateSignatureParams() {
-    if (!this.signingKey.kid)
-      throw new Error("Error generating signature params: kid is required");
-
     const created = Math.floor(Date.now() / 1000);
 
-    const signatureParams = `("@method" "@target-uri" "content-digest"${
+    return `("@method" "@target-uri" "content-digest"${
       this.authorization && ' "authorization"'
     });created=${created};keyid="${this.signingKey.kid}"`;
-
-    return signatureParams;
   }
 
   /**
@@ -69,7 +64,11 @@ export class HTTPSigner {
    */
   getSignatureInput(name, sigParams) {
     if (!name)
-      throw new Error("Error getting signature input: name is required");
+      throw new TypeError("Error getting signature input: name is required");
+    if (!sigParams)
+      throw new TypeError(
+        "Error getting signature input: signature parameters are required"
+      );
     return `${name}=${sigParams}`;
   }
 
@@ -94,12 +93,15 @@ export class HTTPSigner {
    */
   async sign(digest, url, name, sigParams) {
     if (!digest)
-      throw new Error("Error generating a signature: digest is missing");
+      throw new TypeError("Error generating a signature: digest is missing");
     if (!url)
-      throw new Error("Error generating a signature: server url is missing");
-    if (!name) throw new Error("Error generating a signature: name is missing");
+      throw new TypeError(
+        "Error generating a signature: server url is missing"
+      );
+    if (!name)
+      throw new TypeError("Error generating a signature: name is missing");
     if (!sigParams)
-      throw new Error(
+      throw new TypeError(
         "Error generating a signature: signature parameters are missing"
       );
 

--- a/cmd/wallet-js-sdk/test/specs/httpsig/signer.spec.js
+++ b/cmd/wallet-js-sdk/test/specs/httpsig/signer.spec.js
@@ -1,0 +1,265 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { HTTPSigner } from "../../../src";
+import MockDate from "mockdate";
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe("HTTP Signature Client - Constructor", function () {
+  it("throws an error constructing signer instance with empty signingKey", () => {
+    expect(() => new HTTPSigner({ signingKey: null })).to.throw(
+      TypeError,
+      "Error initializing HTTPSigner: signingKey cannot be empty"
+    );
+  });
+  it("throws an error constructing signer instance when privateKey is missing", () => {
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      kid: "mock-kid",
+    };
+
+    expect(() => new HTTPSigner({ signingKey: mockSigningKey })).to.throw(
+      TypeError,
+      "Error initializing HTTPSigner: privateKey cannot be empty"
+    );
+  });
+  it("throws an error constructing signer instance when publicKey is missing", () => {
+    const mockSigningKey = {
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+
+    expect(() => new HTTPSigner({ signingKey: mockSigningKey })).to.throw(
+      TypeError,
+      "Error initializing HTTPSigner: publicKey cannot be empty"
+    );
+  });
+  it("throws an error constructing signer instance when kid is missing", () => {
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+    };
+
+    expect(() => new HTTPSigner({ signingKey: mockSigningKey })).to.throw(
+      TypeError,
+      "Error initializing HTTPSigner: kid cannot be empty"
+    );
+  });
+  it("successfully constructs signer instance", () => {
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+    const signer = new HTTPSigner({ signingKey: mockSigningKey });
+
+    expect(signer).to.be.an.instanceOf(HTTPSigner);
+    expect(signer).to.have.property("signingKey");
+    expect(signer.signingKey).to.have.property("publicKey");
+    expect(signer.signingKey.publicKey).to.equal("mock-public-key");
+    expect(signer.signingKey).to.have.property("privateKey");
+    expect(signer.signingKey.privateKey).to.equal("mock-private-key");
+    expect(signer.signingKey).to.have.property("kid");
+    expect(signer.signingKey.kid).to.equal("mock-kid");
+  });
+  it("successfully constructs signer instance with authorization", () => {
+    const mockAuthorization = "mock-authorization";
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+    const signer = new HTTPSigner({
+      authorization: mockAuthorization,
+      signingKey: mockSigningKey,
+    });
+
+    expect(signer).to.be.an.instanceOf(HTTPSigner);
+    expect(signer).to.have.property("authorization");
+    expect(signer.authorization).to.equal("mock-authorization");
+    expect(signer).to.have.property("signingKey");
+    expect(signer.signingKey).to.have.property("publicKey");
+    expect(signer.signingKey.publicKey).to.equal("mock-public-key");
+    expect(signer.signingKey).to.have.property("privateKey");
+    expect(signer.signingKey.privateKey).to.equal("mock-private-key");
+    expect(signer.signingKey).to.have.property("kid");
+    expect(signer.signingKey.kid).to.equal("mock-kid");
+  });
+});
+describe("HTTP Signature Client - Generating Parameters", function () {
+  MockDate.set("1999-04-03");
+  it("successfully generates signature params", () => {
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+    const mockCreated = Math.floor(Date.now() / 1000);
+    const signer = new HTTPSigner({ signingKey: mockSigningKey });
+
+    const sigParams = signer.generateSignatureParams();
+
+    expect(sigParams).to.be.a("string");
+    expect(sigParams).to.equal(
+      `("@method" "@target-uri" "content-digest");created=${mockCreated};keyid="${signer.signingKey.kid}"`
+    );
+  });
+  it("successfully generates signature params with authorization", () => {
+    const mockAuthorization = "mock-authorization";
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+    const mockCreated = Math.floor(Date.now() / 1000);
+    const signer = new HTTPSigner({
+      authorization: mockAuthorization,
+      signingKey: mockSigningKey,
+    });
+
+    const sigParams = signer.generateSignatureParams();
+
+    expect(sigParams).to.be.a("string");
+    expect(sigParams).to.equal(
+      `("@method" "@target-uri" "content-digest" "authorization");created=${mockCreated};keyid="${signer.signingKey.kid}"`
+    );
+  });
+});
+describe("HTTP Signature Client - Getting Signature Input", function () {
+  it("successfully gets signature input", () => {
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+    const mockSigName = "mock-sig-name";
+    const mockSigParams = `("@method" "@target-uri" "content-digest" "authorization");created=123456789;keyid="mock-kid"`;
+
+    const signer = new HTTPSigner({ signingKey: mockSigningKey });
+
+    const sigInput = signer.getSignatureInput(mockSigName, mockSigParams);
+
+    expect(sigInput).to.be.a("string");
+    expect(sigInput).to.equal(`${mockSigName}=${mockSigParams}`);
+  });
+  it("throws an error when name is missing", () => {
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+    const mockSigParams = `("@method" "@target-uri" "content-digest" "authorization");created=123456789;keyid="mock-kid"`;
+
+    const signer = new HTTPSigner({ signingKey: mockSigningKey });
+
+    expect(() => signer.getSignatureInput(null, mockSigParams)).to.throw(
+      TypeError,
+      "Error getting signature input: name is required"
+    );
+  });
+  it("throws an error when signature params are missing", () => {
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+    const mockName = "mock-name";
+
+    const signer = new HTTPSigner({ signingKey: mockSigningKey });
+
+    expect(() => signer.getSignatureInput(mockName, null)).to.throw(
+      TypeError,
+      "Error getting signature input: signature parameters are required"
+    );
+  });
+});
+describe("HTTP Signature Client - Signing", function () {
+  it("throws an error when digest is missing", async () => {
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+    const mockUrl = "mock-url";
+    const mockSigName = "mock-sig-name";
+    const mockSigParams = "mock-sig-params";
+
+    const signer = new HTTPSigner({ signingKey: mockSigningKey });
+
+    expect(
+      signer.sign({
+        digest: null,
+        url: mockUrl,
+        name: mockSigName,
+        sigParams: mockSigParams,
+      })
+    ).to.eventually.throw(
+      TypeError,
+      "Error generating a signature: digest is missing"
+    );
+  });
+  it("throws an error when url is missing", async () => {
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+    const mockDigest = "mock-digest";
+    const mockSigName = "mock-sig-name";
+    const mockSigParams = "mock-sig-params";
+
+    const signer = new HTTPSigner({ signingKey: mockSigningKey });
+
+    expect(
+      signer.sign(mockDigest, null, mockSigName, mockSigParams)
+    ).to.eventually.throw(
+      TypeError,
+      "Error generating a signature: server url is missing"
+    );
+  });
+  it("throws an error when signature name is missing", async () => {
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+    const mockDigest = "mock-digest";
+    const mockUrl = "mock-url";
+    const mockSigParams = "mock-sig-params";
+
+    const signer = new HTTPSigner({ signingKey: mockSigningKey });
+
+    expect(
+      signer.sign(mockDigest, mockUrl, null, mockSigParams)
+    ).to.eventually.throw(
+      TypeError,
+      "Error generating a signature: name is missing"
+    );
+  });
+  it("throws an error when signature parameters are missing", async () => {
+    const mockSigningKey = {
+      publicKey: "mock-public-key",
+      privateKey: "mock-private-key",
+      kid: "mock-kid",
+    };
+    const mockDigest = "mock-digest";
+    const mockUrl = "mock-url";
+    const mockSigName = "mock-sig-name";
+
+    const signer = new HTTPSigner({ signingKey: mockSigningKey });
+
+    expect(
+      signer.sign(mockDigest, mockUrl, mockSigName, null)
+    ).to.eventually.throw(
+      TypeError,
+      "Error generating a signature: signature parameters are missing"
+    );
+  });
+});


### PR DESCRIPTION
Fixes #386

Covered most test cases apart from actually siging the request successfully since we would need to implement a verifier to be able to cover that. This test case is covered in wallet end-to-end tests.

Signed-off-by: Anton Biriukov <anton.biriukov@avast.com>