### PR TITLE
fix: Docker warning when using frapsoft/openssl on arm64 system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,11 @@ generate-openapi-demo-specs: clean generate-openapi-spec agent-server-docker
     	DOCKER_IMAGE=$(OPENAPI_DOCKER_IMG) DOCKER_IMAGE_VERSION=$(OPENAPI_DOCKER_IMG_VERSION)  \
     	scripts/generate-openapi-demo-specs.sh
 
+# TODO (#419): frapsoft/openssl only has an amd64 version. While this does work under amd64 and arm64 Mac OS currently,
+#               we should add an arm64 version for systems that can only run arm64 code.
 generate-test-keys: clean
 	@mkdir -p -p deployments/keys/tls
-	@docker run -i --rm \
+	@docker run -i --platform linux/amd64 --rm \
 		-v $(abspath .):/opt/go/src/$(PROJECT_ROOT) \
 		--entrypoint "/opt/go/src/$(PROJECT_ROOT)/scripts/generate_test_keys.sh" \
 		frapsoft/openssl


### PR DESCRIPTION
Resolved a warning from Docker that would get printed when running the generate-test-keys Makefile target on an arm64 system. The warning from Docker alerts you that the image for frapsoft/openssl is for amd64, which doesn't match the system you're on (when using an arm64-based OS). To resolve the warning, you have to either use an image that matches the system architecture, or explicitly state the platform using the --platform flag. In this case, there is only an amd64 version of frapsoft/openssl, so I added the explicit flag to resolve the warning. I also added a TODO for us to find an arm64 alternative in the future (although the amd64 version of frapsoft/openssl does seem to work fine on arm64 Mac OS currently, presumably due to Apple's Rosetta translation layer or some other emulation layer).

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>