### PR TITLE
feat: implemented OpenID4VP client and Initiate API

### DIFF
--- a/cmd/wallet-js-sdk/package-lock.json
+++ b/cmd/wallet-js-sdk/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
+        "jose": "^4.10.0",
         "js-base64": "^3.7.2",
         "jsonpath": "^1.1.1",
         "uuid": "^8.3.2"
@@ -33,6 +34,7 @@
         "mockdate": "^3.0.5",
         "moxios": "^0.4.0",
         "prettier": "^2.6.2",
+        "sinon": "^14.0.1",
         "terser-webpack-plugin": "^5.3.3",
         "webpack": "^5.73.0",
         "webpack-cli": "^4.9.2",
@@ -156,6 +158,41 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
+      "dev": true
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "node_modules/@trustbloc-cicd/agent-sdk-web": {
@@ -3052,6 +3089,14 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/jose": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.10.0.tgz",
+      "integrity": "sha512-KEhB/eLGLomWGPTb+/RNbYsTjIyx03JmbqAyIyiXBuNSa7CmNrJd5ysFhblayzs/e/vbOPMUaLnjHUMhGp4yLw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-base64": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
@@ -3203,6 +3248,12 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
     },
     "node_modules/karma": {
       "version": "6.4.0",
@@ -3420,6 +3471,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.omit": {
@@ -3889,6 +3946,34 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -4906,6 +4991,36 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/sinon": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.1.tgz",
+      "integrity": "sha512-JhJ0jCiyBWVAHDS+YSjgEbDn7Wgz9iIjA1/RK+eseJN0vAAWIWiXBdrnb92ELPyjsfreCYntD1ORtLSfIrlvSQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/socket.io": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.1.tgz",
@@ -5346,9 +5461,9 @@
       "dev": true
     },
     "node_modules/terser": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -6265,6 +6380,41 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "@trustbloc-cicd/agent-sdk-web": {
@@ -8552,6 +8702,11 @@
         "supports-color": "^8.0.0"
       }
     },
+    "jose": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.10.0.tgz",
+      "integrity": "sha512-KEhB/eLGLomWGPTb+/RNbYsTjIyx03JmbqAyIyiXBuNSa7CmNrJd5ysFhblayzs/e/vbOPMUaLnjHUMhGp4yLw=="
+    },
     "js-base64": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
@@ -8682,6 +8837,12 @@
           "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
         }
       }
+    },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
     },
     "karma": {
       "version": "6.4.0",
@@ -8861,6 +9022,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.omit": {
@@ -9224,6 +9391,36 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "no-case": {
       "version": "3.0.4",
@@ -9995,6 +10192,31 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "sinon": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.1.tgz",
+      "integrity": "sha512-JhJ0jCiyBWVAHDS+YSjgEbDn7Wgz9iIjA1/RK+eseJN0vAAWIWiXBdrnb92ELPyjsfreCYntD1ORtLSfIrlvSQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "socket.io": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.1.tgz",
@@ -10339,9 +10561,9 @@
       "dev": true
     },
     "terser": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",

--- a/cmd/wallet-js-sdk/package.json
+++ b/cmd/wallet-js-sdk/package.json
@@ -55,6 +55,7 @@
     "mockdate": "^3.0.5",
     "moxios": "^0.4.0",
     "prettier": "^2.6.2",
+    "sinon": "^14.0.1",
     "terser-webpack-plugin": "^5.3.3",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.9.2",
@@ -63,6 +64,7 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
+    "jose": "^4.10.0",
     "js-base64": "^3.7.2",
     "jsonpath": "^1.1.1",
     "uuid": "^8.3.2"

--- a/cmd/wallet-js-sdk/src/index.js
+++ b/cmd/wallet-js-sdk/src/index.js
@@ -1,5 +1,6 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -27,3 +28,4 @@ export { DeviceLogin } from "./device/login";
 export { DeviceRegister } from "./device/register";
 export { Client as GNAPClient } from "./gnap/client";
 export { HTTPSigner } from "./httpsig/signer";
+export { OpenID4VP } from "./oidc/presentation/openid4vp";

--- a/cmd/wallet-js-sdk/src/oidc/presentation/openid4vp.js
+++ b/cmd/wallet-js-sdk/src/oidc/presentation/openid4vp.js
@@ -1,0 +1,113 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import axios from "axios";
+import { decode } from "js-base64";
+import { CredentialManager, DIDManager } from "@";
+import * as jose from "jose";
+
+/**
+ *  oidc module is the oidc client that provides APIs for OIDC4VC flows.
+ *
+ *  @module oidc
+ *
+ */
+
+/**
+ * Client providing support for OIDC4VC methods.
+ *
+ * @alias module:oidc
+ */
+export class OpenID4VP {
+  // Creates a new OpenID4VP client
+  constructor({ agent, user }) {
+    if (!agent) {
+      throw new TypeError(
+        "Error initializing OIDC client: agent cannot be empty"
+      );
+    } else if (!user) {
+      throw new TypeError(
+        "Error initializing OIDC client: user cannot be empty"
+      );
+    }
+    this.user = user;
+    this.credentialManager = new CredentialManager({ agent, user });
+    this.didManager = new DIDManager({ agent, user });
+  }
+
+  async initiateOIDCPresentation(url, authToken) {
+    if (!url) {
+      throw new TypeError("Error initiating OIDC presentation: url is missing");
+    }
+    const requestURI = new URLSearchParams(url).get("openid-vc://?request_uri");
+    if (!requestURI) {
+      throw new TypeError(
+        "Error initiating OIDC presentation: request_uri is missing"
+      );
+    }
+
+    // Get base64url-encoded request object
+    const encodedRequestToken = await axios(requestURI)
+      .then((resp) => resp.data)
+      .catch((e) => {
+        throw new Error(
+          "Error initiating OIDC presentation: failed to get request token:",
+          e
+        );
+      });
+
+    const encodedRequestTokenArray = encodedRequestToken.split(".");
+
+    const header = JSON.parse(decode(encodedRequestTokenArray[0]));
+    const payload = JSON.parse(decode(encodedRequestTokenArray[1]));
+
+    const didDoc = await this.didManager.resolveWebDIDFromOrbDID(
+      "",
+      header.kid
+    );
+
+    const { publicKeyJwk } = didDoc.verificationMethod.find(
+      (keyPair) => keyPair.id.split("#")[0] === header.kid
+    );
+    const publicKey = await jose.importJWK(publicKeyJwk, header.alg);
+
+    this.verificationMethodId = didDoc.verificationMethod.id;
+
+    try {
+      // TODO: https://github.com/trustbloc/agent-sdk/issues/449
+      await jose.compactVerify(encodedRequestToken, publicKey);
+    } catch (e) {
+      console.error(e);
+      throw new Error(
+        "Error initiating OIDC presentation: signature verification failed",
+        e
+      );
+    }
+
+    const claims = payload.claims;
+
+    // Get Presentation Query
+    const { results } = await this.credentialManager
+      .query(authToken, [
+        {
+          type: "PresentationExchange",
+          credentialQuery: [claims.vp_token],
+        },
+      ])
+      .catch((e) => {
+        console.error(e);
+        // Error code 12009 is for no result found message
+        if (!e.message.includes("12009")) {
+          return new Error(
+            "Error initiating credential share: requested credentials were not found"
+          );
+        }
+      });
+
+    return results;
+  }
+}

--- a/cmd/wallet-js-sdk/test/fixtures/testdata/openid4vc-mock-did-doc.json
+++ b/cmd/wallet-js-sdk/test/fixtures/testdata/openid4vc-mock-did-doc.json
@@ -1,0 +1,44 @@
+{
+  "@context": ["https://w3id.org/did/v1"],
+  "id": "did:key:zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u",
+  "verificationMethod": [
+    {
+      "controller": "did:key:zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u",
+      "id": "did:key:zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u#zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u",
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "F-3jdnJCK-McATvRmGEp3trVUmvh4MDGxzmFrvFksLY",
+        "y": "gcxVa38yvNnIZKUt12AbLS2IgANk0MvUaGTvnXmHL_Q"
+      },
+      "type": "JsonWebKey2020"
+    }
+  ],
+  "authentication": [
+    "did:key:zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u#zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u"
+  ],
+  "assertionMethod": [
+    "did:key:zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u#zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u"
+  ],
+  "capabilityDelegation": [
+    "did:key:zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u#zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u"
+  ],
+  "capabilityInvocation": [
+    "did:key:zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u#zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u"
+  ],
+  "keyAgreement": [
+    {
+      "controller": "did:key:zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u",
+      "id": "did:key:zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u#zDnaeS3Np7MGVK3ht59S6V5AJSpuar4qd9gR3T5TPNRojAC4u",
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "F-3jdnJCK-McATvRmGEp3trVUmvh4MDGxzmFrvFksLY",
+        "y": "gcxVa38yvNnIZKUt12AbLS2IgANk0MvUaGTvnXmHL_Q"
+      },
+      "type": "JsonWebKey2020"
+    }
+  ],
+  "created": "2022-10-24T18:36:55.219888-04:00",
+  "updated": "2022-10-24T18:36:55.219888-04:00"
+}

--- a/cmd/wallet-js-sdk/test/specs/oidc/presentation/openid4vp.spec.js
+++ b/cmd/wallet-js-sdk/test/specs/oidc/presentation/openid4vp.spec.js
@@ -1,0 +1,143 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { expect } from "chai";
+import moxios from "moxios";
+import sinon from "sinon";
+import {
+  getJSONTestData,
+  loadFrameworks,
+  testConfig,
+  prepareTestManifest,
+} from "../../common";
+import {
+  createWalletProfile,
+  CollectionManager,
+  CredentialManager,
+  OpenID4VP,
+  UniversalWallet,
+} from "@";
+import { IssuerAdapter } from "../../mocks/adapters";
+
+const VC_ISSUER = "vc-issuer-agent";
+const PRC_DESCRIPTOR_ID = "prc_output";
+const VC_FORMAT = "ldp_vc";
+const USER_ID = "agent";
+const MOCK_REQUEST_URL =
+  "openid-vc://?request_uri=https://someverifierdomain.com/v1.0/verifiablecredentials/request/a0eed079-672f-4055-a4f5-e0f5d76ecdea";
+const MOCK_JWT =
+  "eyJhbGciOiJFUzI1NiIsImNydiI6IlAtMjU2Iiwia2lkIjoiZGlkOmtleTp6RG5hZVMzTnA3TUdWSzNodDU5UzZWNUFKU3B1YXI0cWQ5Z1IzVDVUUE5Sb2pBQzR1IiwidHlwIjoiSldUIn0.CgkJewoJCSAgImNsYWltcyI6IHsKCQkJInZwX3Rva2VuIjogewoJCQkgICJpZCI6ICIyMmM3NzE1NS1lZGYyLTRlYzUtOGQ0NC1iMzkzYjRlNGZhMzgiLAoJCQkgICJpbnB1dF9kZXNjcmlwdG9ycyI6IFsKCQkJCXsKCQkJCSAgImlkIjogIjIwYjA3M2JiLWNlZGUtNDkxMi05ZTlkLTMzNGU1NzAyMDc3YiIsCgkJCQkgICJzY2hlbWEiOiBbCgkJCQkJewoJCQkJCSAgInVyaSI6ICJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscyNWZXJpZmlhYmxlQ3JlZGVudGlhbCIKCQkJCQl9CgkJCQkgIF0sCgkJCQkgICJjb25zdHJhaW50cyI6IHsKCQkJCQkiZmllbGRzIjogWwoJCQkJCSAgewoJCQkJCQkicGF0aCI6IFsKCQkJCQkJICAiJC5jcmVkZW50aWFsU3ViamVjdC5mYW1pbHlOYW1lIgoJCQkJCQldCgkJCQkJICB9CgkJCQkJXQoJCQkJICB9CgkJCQl9CgkJCSAgXQoJCQl9CgkJICB9CgkJfQoJ.o6ldJYTHMbmr7xhqaI-CznY8k9yNjQT7Rhzd4Ns_iBYg6Maj4qhiN7mKEFS9drWbj9v_bN65G44c0qyYcpYJEA";
+const MOCK_DID_DOC = getJSONTestData("openid4vc-mock-did-doc.json");
+
+let agent, issuer, samplePRC;
+
+before(async function () {
+  agent = await loadFrameworks({ name: USER_ID });
+
+  issuer = new IssuerAdapter(VC_ISSUER);
+  await issuer.init();
+
+  // load sample VC from testdata
+  const prcVC = getJSONTestData("prc-vc.json");
+
+  // issue sample credential
+  const [vc] = await issuer.issue(prcVC);
+  expect(vc.id).to.not.empty;
+  expect(vc.credentialSubject).to.not.empty;
+
+  samplePRC = vc;
+});
+
+after(function () {
+  agent ? agent.destroy() : "";
+});
+
+describe("OpenID4VP tests", async function () {
+  beforeEach(function () {
+    moxios.install();
+  });
+
+  afterEach(function () {
+    moxios.uninstall();
+  });
+
+  it("user creates his wallet profile", async function () {
+    await createWalletProfile(agent, USER_ID, {
+      localKMSPassphrase: testConfig.walletUserPassphrase,
+    });
+  });
+
+  let authToken;
+  it("user opens wallet", async function () {
+    const wallet = new UniversalWallet({ agent: agent, user: USER_ID });
+    const authResponse = await wallet.open({
+      localKMSPassphrase: testConfig.walletUserPassphrase,
+    });
+    expect(authResponse).to.have.property("token");
+    expect(authResponse.token).to.have.a.lengthOf.above(0);
+    authToken = authResponse.token;
+  });
+
+  let collection;
+  it("user saves a credential into wallet", async function () {
+    const credentialManager = new CredentialManager({
+      agent: agent,
+      user: USER_ID,
+    });
+
+    const collectionManager = new CollectionManager({
+      agent: agent,
+      user: USER_ID,
+    });
+    collection = await collectionManager.create(authToken, {
+      name: "sample-name",
+      description: "sample description",
+    });
+    expect(collection).to.not.empty;
+
+    await credentialManager.save(
+      authToken,
+      { credentials: [samplePRC] },
+      {
+        verify: true,
+        manifest: prepareTestManifest("prc-cred-manifest.json"),
+        descriptorMap: [
+          {
+            id: PRC_DESCRIPTOR_ID,
+            format: VC_FORMAT,
+            path: "$[0]",
+          },
+        ],
+      }
+    );
+  });
+
+  let openID4VP;
+  it("successfully creates OpenID4VP client", function () {
+    openID4VP = new OpenID4VP({ agent: agent, user: USER_ID });
+    expect(openID4VP).to.be.an.instanceof(Object);
+  });
+
+  it("successfully initiates presentation", async function () {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({ status: 200, response: MOCK_JWT });
+    }, 5);
+
+    sinon
+      .stub(openID4VP.didManager, "resolveWebDIDFromOrbDID")
+      .callsFake(() => MOCK_DID_DOC);
+
+    const presentationQuery = await openID4VP.initiateOIDCPresentation(
+      MOCK_REQUEST_URL,
+      authToken
+    );
+
+    expect(presentationQuery).to.have.lengthOf(1);
+    expect(presentationQuery[0].verifiableCredential).to.have.lengthOf(1);
+  });
+});

--- a/cmd/wallet-js-sdk/webpack.common.js
+++ b/cmd/wallet-js-sdk/webpack.common.js
@@ -1,41 +1,54 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
 
-const path = require('path');
+const path = require("path");
 const TerserPlugin = require("terser-webpack-plugin");
-const isSnapshot = require('./package.json').dependencies.hasOwnProperty("@trustbloc-cicd/agent-sdk-web")
-const isSnapshotDev = require('./package.json').devDependencies.hasOwnProperty("@trustbloc-cicd/agent-sdk-web")
-const agent_sdk = (isSnapshot || isSnapshotDev) ? "@trustbloc-cicd/agent-sdk-web" : "@trustbloc/agent-sdk-web"
+const isSnapshot = require("./package.json").dependencies.hasOwnProperty(
+  "@trustbloc-cicd/agent-sdk-web"
+);
+const isSnapshotDev = require("./package.json").devDependencies.hasOwnProperty(
+  "@trustbloc-cicd/agent-sdk-web"
+);
+const agent_sdk =
+  isSnapshot || isSnapshotDev
+    ? "@trustbloc-cicd/agent-sdk-web"
+    : "@trustbloc/agent-sdk-web";
+
+const srcPath = "src";
 
 module.exports = {
-    entry: {
-        'wallet-sdk':'./src/index.js',
+  entry: {
+    "wallet-sdk": "./src/index.js",
+  },
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: "[name].min.js",
+    libraryTarget: "umd",
+    library: {
+      name: "walletSDK",
+      type: "umd",
     },
-    output: {
-        path: path.resolve(__dirname, 'dist'),
-        filename: '[name].min.js',
-        libraryTarget: 'umd',
-        library: {
-            name: 'walletSDK',
-            type: 'umd',
-        },
-        clean: true,
+    clean: true,
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        extractComments: false,
+      }),
+    ],
+  },
+  resolve: {
+    alias: {
+      "@trustbloc/agent-sdk-web": path.resolve(
+        __dirname,
+        "node_modules/" + agent_sdk
+      ),
+      "@": path.resolve(__dirname, srcPath),
     },
-    optimization: {
-        minimize: true,
-        minimizer: [
-            new TerserPlugin({
-                extractComments: false,
-            }),
-        ],
-    },
-    resolve: {
-        alias: {
-            "@trustbloc/agent-sdk-web": path.resolve(__dirname, 'node_modules/' + agent_sdk)
-        }
-    }
+  },
 };
-


### PR DESCRIPTION
Fixes #432

Basic implementation and unit tests for OpenID4VP Initiate API. Unfortunately, the EdDSA and ES256K signature are not supported in the browser runtime, so this implementation uses `ES256`. 

Signed-off-by: Anton Biriukov <anton.biriukov@avast.com>